### PR TITLE
Fix/75 bug with scatterplot colorscale when first selecting gene

### DIFF
--- a/src/lib/components/obs-list/ObsList.js
+++ b/src/lib/components/obs-list/ObsList.js
@@ -121,7 +121,7 @@ export function ObsColsList({ showColor = true }) {
 
   const toggleColor = (item) => {
     dispatch({ type: "select.obs", obs: item });
-    dispatch({ type: "set.colorEncoding", value: "obs" });
+    dispatch({ type: "set.colorEncoding", value: COLOR_ENCODINGS.OBS });
   };
 
   const toggleObs = (item, value) => {

--- a/src/lib/components/obsm-list/ObsmList.js
+++ b/src/lib/components/obsm-list/ObsmList.js
@@ -37,7 +37,7 @@ export function ObsmKeysList() {
   });
 
   useEffect(() => {
-    if (!isPending && !serverError) {
+    if (!isPending && !serverError && fetchedData) {
       setObsmKeysList(fetchedData);
     }
   }, [fetchedData, isPending, serverError]);

--- a/src/lib/components/pseudospatial/Pseudospatial.js
+++ b/src/lib/components/pseudospatial/Pseudospatial.js
@@ -171,7 +171,7 @@ export function Pseudospatial({
     usePseudospatialData(plotType);
 
   useEffect(() => {
-    if (!isPending && !serverError) {
+    if (!isPending && !serverError && fetchedData) {
       setData(fetchedData.data);
       setLayout(fetchedData.layout);
       updateColorscale(colorscale.current);

--- a/src/lib/components/var-list/VarItem.js
+++ b/src/lib/components/var-list/VarItem.js
@@ -136,7 +136,7 @@ export function SingleSelectionItem({
     enabled: !!dataset.diseaseDatasets.length,
   });
 
-  const hasDiseaseInfo = !isPending && !serverError && !!fetchedData.length;
+  const hasDiseaseInfo = !isPending && !serverError && !!fetchedData?.length;
 
   return (
     <>
@@ -247,12 +247,16 @@ export function VarItem({
       });
       dispatch({
         type: "set.colorEncoding",
-        value: "var",
+        value: COLOR_ENCODINGS.VAR,
       });
     } else if (mode === SELECTION_MODES.MULTIPLE) {
       dispatch({
         type: "select.multivar",
         var: item,
+      });
+      dispatch({
+        type: "set.colorEncoding",
+        value: COLOR_ENCODINGS.VAR,
       });
     }
   };

--- a/src/lib/components/var-list/VarList.js
+++ b/src/lib/components/var-list/VarList.js
@@ -77,7 +77,7 @@ function DiseaseVarList({ makeListItem }) {
 
   const varMeans = useVarMean(
     diseaseVars,
-    diseaseVars && dataset.varSort.disease.sort === VAR_SORT.MATRIX
+    !!diseaseVars?.length && dataset.varSort.disease.sort === VAR_SORT.MATRIX
   );
 
   useEffect(() => {
@@ -246,7 +246,11 @@ export function VarNamesList({
   // @TODO: deferr sortedVarButtons ?
   useEffect(() => {
     if (dataset.varSort.var.sort === VAR_SORT.MATRIX) {
-      if (!varMeans.isPending && !varMeans.serverError) {
+      if (
+        !varMeans.isPending &&
+        !varMeans.serverError &&
+        varMeans.fetchedData
+      ) {
         setSortedVarButtons(
           _.orderBy(
             varButtons,

--- a/src/lib/helpers/zarr-helper.js
+++ b/src/lib/helpers/zarr-helper.js
@@ -43,7 +43,7 @@ export const useZarr = (
   const { enabled = true } = opts;
   const {
     data = null,
-    isPending = false,
+    isLoading: isPending = false,
     error: serverError = null,
   } = useQuery({
     queryKey: ["zarr", url, path, s],
@@ -88,7 +88,7 @@ export const useMultipleZarr = (
           inputs,
           results.map((result) => result.data)
         ),
-        isPending: results.some((result) => result.isPending),
+        isLoading: results.some((result) => result.isLoading),
         serverError: results.find((result) => result.error),
       };
     },
@@ -97,7 +97,7 @@ export const useMultipleZarr = (
 
   const {
     data = null,
-    isPending = false,
+    isLoading: isPending = false,
     serverError = null,
   } = useQueries({
     queries: inputs.map((input) => ({

--- a/src/lib/helpers/zarr-helper.js
+++ b/src/lib/helpers/zarr-helper.js
@@ -40,20 +40,13 @@ export const useZarr = (
   options = GET_OPTIONS,
   opts = {}
 ) => {
-  const { enabled = true } = opts;
   const {
     data = null,
     isLoading: isPending = false,
     error: serverError = null,
   } = useQuery({
     queryKey: ["zarr", url, path, s],
-    queryFn: () => {
-      if (enabled) {
-        return fetchDataFromZarr(url, path, s, options);
-      } else {
-        return;
-      }
-    },
+    queryFn: () => fetchDataFromZarr(url, path, s, options),
     retry: (failureCount, { error }) => {
       if ([400, 401, 403, 404, 422].includes(error?.status)) return false;
       return failureCount < 3;
@@ -79,8 +72,6 @@ export const useMultipleZarr = (
   opts = {},
   agg = aggregateData
 ) => {
-  const { enabled = true } = opts;
-
   const combine = useCallback(
     (results) => {
       return {
@@ -102,13 +93,7 @@ export const useMultipleZarr = (
   } = useQueries({
     queries: inputs.map((input) => ({
       queryKey: ["zarr", input.url, input.path, input.s],
-      queryFn: () => {
-        if (enabled) {
-          return fetchDataFromZarr(input.url, input.path, input.s, options);
-        } else {
-          return;
-        }
-      },
+      queryFn: () => fetchDataFromZarr(input.url, input.path, input.s, options),
       retry: (failureCount, { error }) => {
         if ([400, 401, 403, 404, 422].includes(error?.status)) return false;
         return failureCount < 3;

--- a/src/lib/utils/Filter.js
+++ b/src/lib/utils/Filter.js
@@ -161,7 +161,7 @@ export const useFilter = (data) => {
         filteredIndices: null,
         valueMin: _.min(obsData.data),
         valueMax: _.max(obsData.data),
-        slicedLength: obsData.data.length,
+        slicedLength: obsData.data?.length,
       };
     }
   }, [

--- a/src/lib/utils/requests.js
+++ b/src/lib/utils/requests.js
@@ -52,7 +52,7 @@ export const useFetch = (
   const { enabled = true } = opts;
   const {
     data: fetchedData = null,
-    isPending = false,
+    isLoading: isPending = false,
     error: serverError = null,
   } = useQuery({
     queryKey: [endpoint, params],
@@ -85,7 +85,7 @@ export const useDebouncedFetch = (
 
   const {
     data: fetchedData = null,
-    isPending = false,
+    isLoading: isPending = false,
     error: serverError = null,
   } = useQuery({
     queryKey: [endpoint, debouncedParams],

--- a/src/lib/utils/requests.js
+++ b/src/lib/utils/requests.js
@@ -49,20 +49,13 @@ export const useFetch = (
   opts = { refetchOnMount: false, refetchOnWindowFocus: false },
   apiUrl = null
 ) => {
-  const { enabled = true } = opts;
   const {
     data: fetchedData = null,
     isLoading: isPending = false,
     error: serverError = null,
   } = useQuery({
     queryKey: [endpoint, params],
-    queryFn: ({ signal }) => {
-      if (enabled) {
-        return fetchData(endpoint, params, signal, apiUrl);
-      } else {
-        return;
-      }
-    },
+    queryFn: ({ signal }) => fetchData(endpoint, params, signal, apiUrl),
     retry: (failureCount, { error }) => {
       if ([400, 401, 403, 404, 422].includes(error?.status)) return false;
       return failureCount < 3;
@@ -80,7 +73,6 @@ export const useDebouncedFetch = (
   opts = { refetchOnMount: false, refetchOnWindowFocus: false },
   apiUrl = null
 ) => {
-  const { enabled = true } = opts;
   const debouncedParams = useDebounce(params, delay);
 
   const {
@@ -89,13 +81,8 @@ export const useDebouncedFetch = (
     error: serverError = null,
   } = useQuery({
     queryKey: [endpoint, debouncedParams],
-    queryFn: ({ signal }) => {
-      if (enabled) {
-        return fetchData(endpoint, debouncedParams, signal, apiUrl);
-      } else {
-        return;
-      }
-    },
+    queryFn: ({ signal }) =>
+      fetchData(endpoint, debouncedParams, signal, apiUrl),
     retry: (failureCount, { error }) => {
       if ([400, 401, 403, 404, 422].includes(error?.status)) return false;
       return failureCount < 3;


### PR DESCRIPTION
when using previous react-query versions the disabled queries were handled with logic within the queryFn as a workaround. with upgraded version, disabled queries returned `isPending = true` and useFilter hook did not trigger the update on the min and max values when initially setting color encoding to "var"
- use `isLoading` instead of `isPending`
- update components to handle null fetchedData
- remove workaround for `enabled`

Fixes #75 