### PR TITLE
Fix/virtualized obs

### DIFF
--- a/src/lib/components/obs-list/ObsItem.js
+++ b/src/lib/components/obs-list/ObsItem.js
@@ -5,6 +5,7 @@ import { Gauge, SparkLineChart } from "@mui/x-charts";
 import _ from "lodash";
 import { Badge, Form, ListGroup } from "react-bootstrap";
 
+import { ObsToolbar } from "./ObsToolbar";
 import { COLOR_ENCODINGS, OBS_TYPES } from "../../constants/constants";
 import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
 import { useFilteredData } from "../../context/FilterContext";
@@ -15,7 +16,6 @@ import { useFetch } from "../../utils/requests";
 import { formatNumerical, FORMATS } from "../../utils/string";
 import { VirtualizedList } from "../../utils/VirtualizedList";
 import { useObsData } from "../../utils/zarrData";
-import { ObsToolbar } from "./ObsToolbar";
 
 const N_BINS = 5;
 
@@ -274,9 +274,6 @@ export function CategoricalObs({
   updateObs,
   toggleAll,
   toggleObs,
-  toggleLabel,
-  toggleSlice,
-  toggleColor,
   showColor = true,
 }) {
   const dataset = useDataset();
@@ -359,6 +356,7 @@ export function CategoricalObs({
         max={max}
         onChange={toggleObs}
         showColor={showColor}
+        estimateSize={40}
       />
     </ListGroup>
   );
@@ -426,15 +424,7 @@ function ObsContinuousStats({ obs }) {
   );
 }
 
-export function ContinuousObs({
-  obs,
-  updateObs,
-  toggleAll,
-  toggleObs,
-  toggleLabel,
-  toggleSlice,
-  toggleColor,
-}) {
+export function ContinuousObs({ obs, updateObs, toggleAll, toggleObs }) {
   const ENDPOINT = "obs/bins";
   const dataset = useDataset();
   const { isSliced } = useFilteredData();
@@ -511,13 +501,7 @@ export function ContinuousObs({
         <>
           <ListGroup variant="flush" className="cherita-list">
             <ListGroup.Item className="cherita-list-item-unstyled">
-              <ObsToolbar
-                item={obs}
-                onToggleAllObs={toggleAll}
-                onToggleLabel={toggleLabel}
-                onToggleSlice={toggleSlice}
-                onToggleColor={toggleColor}
-              />
+              <ObsToolbar item={obs} onToggleAllObs={toggleAll} />
             </ListGroup.Item>
             <VirtualizedList
               getDataAtIndex={getDataAtIndex}

--- a/src/lib/components/obs-list/ObsItem.js
+++ b/src/lib/components/obs-list/ObsItem.js
@@ -5,7 +5,6 @@ import { Gauge, SparkLineChart } from "@mui/x-charts";
 import _ from "lodash";
 import { Badge, Form, ListGroup } from "react-bootstrap";
 
-import { ObsToolbar } from "./ObsToolbar";
 import { COLOR_ENCODINGS, OBS_TYPES } from "../../constants/constants";
 import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
 import { useFilteredData } from "../../context/FilterContext";
@@ -16,6 +15,7 @@ import { useFetch } from "../../utils/requests";
 import { formatNumerical, FORMATS } from "../../utils/string";
 import { VirtualizedList } from "../../utils/VirtualizedList";
 import { useObsData } from "../../utils/zarrData";
+import { ObsToolbar } from "./ObsToolbar";
 
 const N_BINS = 5;
 
@@ -157,115 +157,117 @@ function CategoricalItem({
   const { getColor } = useColor();
 
   return (
-    <ListGroup.Item key={value} className="obs-item">
-      <div className="d-flex align-items-center">
-        <div className="flex-grow-1">
-          <Form.Check
-            className="obs-value-list-check"
-            type="switch"
-            label={label}
-            checked={!isOmitted}
-            onChange={() => onChange(value)}
-          />
-        </div>
+    <div className="virtualized-list-wrapper">
+      <ListGroup.Item key={value} className="obs-item">
         <div className="d-flex align-items-center">
-          <div className="pl-1 m-0 flex-grow-1">
-            <Histogram
-              data={histogramData.data}
-              isPending={histogramData.isPending}
-              altColor={histogramData.altColor}
+          <div className="flex-grow-1">
+            <Form.Check
+              className="obs-value-list-check"
+              type="switch"
+              label={label}
+              checked={!isOmitted}
+              onChange={() => onChange(value)}
             />
           </div>
-          <div className="pl-1 m-0">
-            <Tooltip
-              title={
-                isSliced ? (
-                  <>
-                    Filtered:{" "}
-                    {formatNumerical(filteredStats.pct, FORMATS.EXPONENTIAL)}%
-                    <br />
-                    Total: {formatNumerical(stats.pct, FORMATS.EXPONENTIAL)}%
-                  </>
-                ) : (
-                  `${formatNumerical(stats.pct, FORMATS.EXPONENTIAL)}%`
-                )
-              }
-              placement="left"
-              arrow
-            >
-              <div className="d-flex align-items-center">
-                <Badge className="value-count-badge">
-                  {" "}
-                  {isSliced && (
+          <div className="d-flex align-items-center">
+            <div className="pl-1 m-0 flex-grow-1">
+              <Histogram
+                data={histogramData.data}
+                isPending={histogramData.isPending}
+                altColor={histogramData.altColor}
+              />
+            </div>
+            <div className="pl-1 m-0">
+              <Tooltip
+                title={
+                  isSliced ? (
                     <>
-                      {formatNumerical(parseInt(filteredStats.value_counts))}{" "}
-                      out of{" "}
-                    </>
-                  )}
-                  {formatNumerical(
-                    parseInt(stats.value_counts),
-                    FORMATS.EXPONENTIAL
-                  )}
-                </Badge>
-                <div className="value-pct-gauge-container">
-                  {isSliced ? (
-                    <>
-                      <Gauge
-                        className="pct-gauge filtered-pct-gauge"
-                        value={filteredStats.pct}
-                        text={null}
-                        innerRadius={"50%"}
-                        outerRadius={"75%"}
-                        margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
-                      />
-                      <Gauge
-                        className="pct-gauge"
-                        value={stats.pct}
-                        text={null}
-                        innerRadius={"75%"}
-                        margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
-                      />
+                      Filtered:{" "}
+                      {formatNumerical(filteredStats.pct, FORMATS.EXPONENTIAL)}%
+                      <br />
+                      Total: {formatNumerical(stats.pct, FORMATS.EXPONENTIAL)}%
                     </>
                   ) : (
-                    <Gauge
-                      value={stats.pct}
-                      text={null}
-                      innerRadius={"50%"}
-                      margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
-                    />
-                  )}
-                </div>
-              </div>
-            </Tooltip>
-          </div>
-          {showColor ? (
-            <div className="pl-1">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width={24}
-                height={24}
-                fill="currentColor"
-                viewBox="0 0 10 10"
+                    `${formatNumerical(stats.pct, FORMATS.EXPONENTIAL)}%`
+                  )
+                }
+                placement="left"
+                arrow
               >
-                <rect
-                  x="0"
-                  y="0"
-                  width="10"
-                  height="10"
-                  fill={`rgb(${getColor({
-                    value: (code - min) / (max - min),
-                    categorical: true,
-                    grayOut: isOmitted,
-                    grayParams: { alpha: 1 },
-                    colorEncoding: "obs",
-                  })})`}
-                />
-              </svg>
+                <div className="d-flex align-items-center">
+                  <Badge className="value-count-badge">
+                    {" "}
+                    {isSliced && (
+                      <>
+                        {formatNumerical(parseInt(filteredStats.value_counts))}{" "}
+                        out of{" "}
+                      </>
+                    )}
+                    {formatNumerical(
+                      parseInt(stats.value_counts),
+                      FORMATS.EXPONENTIAL
+                    )}
+                  </Badge>
+                  <div className="value-pct-gauge-container">
+                    {isSliced ? (
+                      <>
+                        <Gauge
+                          className="pct-gauge filtered-pct-gauge"
+                          value={filteredStats.pct}
+                          text={null}
+                          innerRadius={"50%"}
+                          outerRadius={"75%"}
+                          margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+                        />
+                        <Gauge
+                          className="pct-gauge"
+                          value={stats.pct}
+                          text={null}
+                          innerRadius={"75%"}
+                          margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+                        />
+                      </>
+                    ) : (
+                      <Gauge
+                        value={stats.pct}
+                        text={null}
+                        innerRadius={"50%"}
+                        margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+                      />
+                    )}
+                  </div>
+                </div>
+              </Tooltip>
             </div>
-          ) : null}
+            {showColor ? (
+              <div className="pl-1">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width={24}
+                  height={24}
+                  fill="currentColor"
+                  viewBox="0 0 10 10"
+                >
+                  <rect
+                    x="0"
+                    y="0"
+                    width="10"
+                    height="10"
+                    fill={`rgb(${getColor({
+                      value: (code - min) / (max - min),
+                      categorical: true,
+                      grayOut: isOmitted,
+                      grayParams: { alpha: 1 },
+                      colorEncoding: "obs",
+                    })})`}
+                  />
+                </svg>
+              </div>
+            ) : null}
+          </div>
         </div>
-      </div>
-    </ListGroup.Item>
+      </ListGroup.Item>
+    </div>
   );
 }
 
@@ -344,7 +346,7 @@ export function CategoricalObs({
 
   return (
     <ListGroup variant="flush" className="cherita-list">
-      <ListGroup.Item className="cherita-list-item-unstyled">
+      <ListGroup.Item className="unstyled">
         <ObsToolbar item={obs} onToggleAllObs={toggleAll} />
       </ListGroup.Item>
       <VirtualizedList
@@ -356,7 +358,7 @@ export function CategoricalObs({
         max={max}
         onChange={toggleObs}
         showColor={showColor}
-        estimateSize={40}
+        estimateSize={42}
       />
     </ListGroup>
   );
@@ -371,56 +373,54 @@ function ObsContinuousStats({ obs }) {
 
   // @TODO: fix width issue when min/max/etc values are too large
   return (
-    <ListGroup variant="flush" className="cherita-list">
-      <ListGroup.Item className="obs-item">
-        <h5 className="mb-2">Statistics</h5>
-        <div className="row">
-          <div className="col-md-7">
-            <p className="mb-1 small">Distribution of continuous values</p>
-            {isPending && <LoadingLinear />}
-            {!isPending && !serverError && (
-              <div className="obs-distribution">
-                <SparkLineChart
-                  data={fetchedData.kde_values[1]}
-                  showHighlight={true}
-                  showTooltip={true}
-                  margin={{ top: 10, right: 20, bottom: 10, left: 20 }}
-                  xAxis={{
-                    data: fetchedData.kde_values[0],
-                    valueFormatter: (v) =>
-                      `${formatNumerical(v, FORMATS.EXPONENTIAL)}`,
-                  }}
-                  valueFormatter={(v) =>
-                    `${formatNumerical(v, FORMATS.EXPONENTIAL)}`
-                  }
-                  slotProps={{
-                    popper: { className: "feature-histogram-tooltip" },
-                  }}
-                />
-              </div>
-            )}
+    <div className="obs-statistics">
+      <h5 className="mb-2">Statistics</h5>
+      <div className="row">
+        <div className="col-md-7">
+          <p className="mb-1 small">Distribution of continuous values</p>
+          {isPending && <LoadingLinear />}
+          {!isPending && !serverError && (
+            <div className="obs-distribution">
+              <SparkLineChart
+                data={fetchedData.kde_values[1]}
+                showHighlight={true}
+                showTooltip={true}
+                margin={{ top: 10, right: 20, bottom: 10, left: 20 }}
+                xAxis={{
+                  data: fetchedData.kde_values[0],
+                  valueFormatter: (v) =>
+                    `${formatNumerical(v, FORMATS.EXPONENTIAL)}`,
+                }}
+                valueFormatter={(v) =>
+                  `${formatNumerical(v, FORMATS.EXPONENTIAL)}`
+                }
+                slotProps={{
+                  popper: { className: "feature-histogram-tooltip" },
+                }}
+              />
+            </div>
+          )}
+        </div>
+        <div className="col-md-5 d-flex flex-column text-end">
+          <div className="d-flex justify-content-between">
+            <span>Min</span>{" "}
+            <span>{formatNumerical(obs.min, FORMATS.EXPONENTIAL)}</span>
           </div>
-          <div className="col-md-5 d-flex flex-column text-end">
-            <div className="d-flex justify-content-between">
-              <span>Min</span>{" "}
-              <span>{formatNumerical(obs.min, FORMATS.EXPONENTIAL)}</span>
-            </div>
-            <div className="d-flex justify-content-between">
-              <span>Max</span>{" "}
-              <span>{formatNumerical(obs.max, FORMATS.EXPONENTIAL)}</span>
-            </div>
-            <div className="d-flex justify-content-between">
-              <span>Mean</span>{" "}
-              <span>{formatNumerical(obs.mean, FORMATS.EXPONENTIAL)}</span>
-            </div>
-            <div className="d-flex justify-content-between">
-              <span>Median</span>{" "}
-              <span>{formatNumerical(obs.median, FORMATS.EXPONENTIAL)}</span>
-            </div>
+          <div className="d-flex justify-content-between">
+            <span>Max</span>{" "}
+            <span>{formatNumerical(obs.max, FORMATS.EXPONENTIAL)}</span>
+          </div>
+          <div className="d-flex justify-content-between">
+            <span>Mean</span>{" "}
+            <span>{formatNumerical(obs.mean, FORMATS.EXPONENTIAL)}</span>
+          </div>
+          <div className="d-flex justify-content-between">
+            <span>Median</span>{" "}
+            <span>{formatNumerical(obs.median, FORMATS.EXPONENTIAL)}</span>
           </div>
         </div>
-      </ListGroup.Item>
-    </ListGroup>
+      </div>
+    </div>
   );
 }
 
@@ -500,7 +500,7 @@ export function ContinuousObs({ obs, updateObs, toggleAll, toggleObs }) {
       {!serverError && updatedObs && (
         <>
           <ListGroup variant="flush" className="cherita-list">
-            <ListGroup.Item className="cherita-list-item-unstyled">
+            <ListGroup.Item className="unstyled">
               <ObsToolbar item={obs} onToggleAllObs={toggleAll} />
             </ListGroup.Item>
             <VirtualizedList

--- a/src/lib/components/obs-list/ObsItem.js
+++ b/src/lib/components/obs-list/ObsItem.js
@@ -5,6 +5,7 @@ import { Gauge, SparkLineChart } from "@mui/x-charts";
 import _ from "lodash";
 import { Badge, Form, ListGroup } from "react-bootstrap";
 
+import { ObsToolbar } from "./ObsToolbar";
 import { COLOR_ENCODINGS, OBS_TYPES } from "../../constants/constants";
 import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
 import { useFilteredData } from "../../context/FilterContext";
@@ -15,7 +16,6 @@ import { useFetch } from "../../utils/requests";
 import { formatNumerical, FORMATS } from "../../utils/string";
 import { VirtualizedList } from "../../utils/VirtualizedList";
 import { useObsData } from "../../utils/zarrData";
-import { ObsToolbar } from "./ObsToolbar";
 
 const N_BINS = 5;
 

--- a/src/lib/components/obs-list/ObsList.js
+++ b/src/lib/components/obs-list/ObsList.js
@@ -274,7 +274,7 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
                   toggleLabel={() => toggleLabel(item)}
                   toggleSlice={() => toggleSlice(item)}
                   toggleColor={() => toggleColor(item)}
-                  showColor={showColor}
+                  showColor={showColor && isColorEncoding}
                 />
               ) : (
                 <ContinuousObs

--- a/src/lib/components/obs-list/ObsList.js
+++ b/src/lib/components/obs-list/ObsList.js
@@ -14,6 +14,7 @@ import Accordion from "react-bootstrap/Accordion";
 import { useAccordionButton } from "react-bootstrap/AccordionButton";
 import AccordionContext from "react-bootstrap/AccordionContext";
 
+import { CategoricalObs, ContinuousObs } from "./ObsItem";
 import {
   COLOR_ENCODINGS,
   DEFAULT_OBS_GROUP,
@@ -22,7 +23,6 @@ import {
 import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
 import { LoadingSpinner } from "../../utils/LoadingIndicators";
 import { useFetch } from "../../utils/requests";
-import { CategoricalObs, ContinuousObs } from "./ObsItem";
 
 // @TODO: integrate ObsAccordionToggle with ObsColsList active, expandedItems, etc. to avoid duplication
 

--- a/src/lib/utils/VirtualizedList.js
+++ b/src/lib/utils/VirtualizedList.js
@@ -8,7 +8,7 @@ export function VirtualizedList({
   ItemComponent,
   estimateSize = 45,
   overscan = 25,
-  maxHeight = "80vh",
+  maxHeight = "65vh",
   ...props
 }) {
   const [parentNode, setParentNode] = useState(null);

--- a/src/lib/utils/VirtualizedList.js
+++ b/src/lib/utils/VirtualizedList.js
@@ -50,7 +50,6 @@ export function VirtualizedList({
             top: 0,
             left: 0,
             width: "100%",
-            height: `${itemVirtualizer.getTotalSize() - (virtualItems[0]?.start ?? 0)}px`,
             transform: `translateY(${virtualItems[0]?.start ?? 0}px)`,
           }}
         >

--- a/src/lib/utils/VirtualizedList.js
+++ b/src/lib/utils/VirtualizedList.js
@@ -50,6 +50,7 @@ export function VirtualizedList({
             top: 0,
             left: 0,
             width: "100%",
+            height: `${itemVirtualizer.getTotalSize() - virtualItems[0]?.start ?? 0}px`,
             transform: `translateY(${virtualItems[0]?.start ?? 0}px)`,
           }}
         >

--- a/src/lib/utils/VirtualizedList.js
+++ b/src/lib/utils/VirtualizedList.js
@@ -50,7 +50,7 @@ export function VirtualizedList({
             top: 0,
             left: 0,
             width: "100%",
-            height: `${itemVirtualizer.getTotalSize() - virtualItems[0]?.start ?? 0}px`,
+            height: `${itemVirtualizer.getTotalSize() - (virtualItems[0]?.start ?? 0)}px`,
             transform: `translateY(${virtualItems[0]?.start ?? 0}px)`,
           }}
         >

--- a/src/scss/components/lists.scss
+++ b/src/scss/components/lists.scss
@@ -1,14 +1,26 @@
-.list-group-flush.cherita-list {
-  .list-group-item.cherita-list-item-unstyled {
+.list-group.cherita-list {
+  .virtualized-list-wrapper {
+    padding: 0 0.25rem 0.25rem 0.25rem;
+  }
+  .list-group-item.unstyled {
     background-color: transparent;
+    padding-left: 1rem;
   }
   .list-group-item {
     border: 0;
     padding: 0.375rem 0.75rem;
-    margin-bottom: 0.215rem;
     line-height: 1.5;
     color: var(--#{$prefix}body-color);
     background-color: var(--#{$prefix}tertiary-bg);
     border-radius: var(--#{$prefix}border-radius);
   }
+}
+.obs-statistics {
+  border: 0;
+  margin: 0 0.25rem 0.25rem 0.25rem;
+  padding: 0.375rem 0.75rem;
+  line-height: 1.5;
+  color: var(--#{$prefix}body-color);
+  background-color: var(--#{$prefix}tertiary-bg);
+  border-radius: var(--#{$prefix}border-radius);
 }


### PR DESCRIPTION
attempt to fix unnecessary scrollbars on obs with few items
- parent div of virtualized items with absolute position gets a height slightly larger than its parent that gets its height from `itemVirtualizer.getTotalSize()` edit: issues caused by margin in obs items
- ~~attempt to fix by setting the height of the virtualized items parent div directly using `itemVirtualizer.getTotalSize() - virtualItems[0]?.start ?? 0` . seems to work on obs with very few items at least~~ edit: fix by removing margin and wrapping items in div with padding

enable categorical obs `showColor` only when `colorEncoding == "obs"` and the obs is the `selectedObs`