### PR TITLE
fix obs accordion bug

### DIFF
--- a/src/lib/components/obs-list/ObsList.js
+++ b/src/lib/components/obs-list/ObsList.js
@@ -27,11 +27,11 @@ import { useFetch } from "../../utils/requests";
 const ObsAccordionToggle = ({ children, eventKey, handleAccordionToggle }) => {
   const { activeEventKey } = useContext(AccordionContext);
 
-  const decoratedOnClick = useAccordionButton(eventKey, () => {
-    handleAccordionToggle(eventKey);
-  });
-
   const isCurrentEventKey = (activeEventKey || []).includes(eventKey);
+
+  const decoratedOnClick = useAccordionButton(eventKey, () => {
+    handleAccordionToggle(eventKey, isCurrentEventKey);
+  });
 
   return (
     <div
@@ -54,7 +54,7 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
   const dispatch = useDatasetDispatch();
   const [enableGroups, setEnableGroups] = useState(enableObsGroups);
   const [obsCols, setObsCols] = useState(null);
-  const [active, setActive] = useState([]);
+  const [active, setActive] = useState([...[dataset.selectedObs?.name]]);
   const [params, setParams] = useState({ url: dataset.url });
   const obsGroups = useMemo(
     () => ({
@@ -124,13 +124,11 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
     });
   };
 
-  const handleAccordionToggle = (itemName) => {
-    if (active.includes(itemName)) {
+  const handleAccordionToggle = (itemName, isCurrentEventKey) => {
+    if (isCurrentEventKey) {
       _.delay(() => setActive((prev) => _.without(prev, itemName)), 250);
     } else {
-      setActive((prev) => {
-        return [...prev, itemName];
-      });
+      setActive((prev) => [...prev, itemName]);
     }
   };
 
@@ -320,7 +318,7 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
         ) : (
           <Accordion
             flush
-            defaultActiveKey={[active]}
+            defaultActiveKey={active}
             alwaysOpen
             className="obs-accordion"
           >

--- a/src/lib/components/obs-list/ObsList.js
+++ b/src/lib/components/obs-list/ObsList.js
@@ -306,6 +306,10 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
     )
   );
 
+  const defaultActiveGroup = enableGroups
+    ? `group-${_.findKey(obsGroups, (g) => g.includes(active?.[0]))}`
+    : null;
+
   if (!serverError) {
     return (
       <div className="position-relative h-100">
@@ -316,7 +320,7 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
         ) : (
           <Accordion
             flush
-            defaultActiveKey={active}
+            defaultActiveKey={[...active, ...[defaultActiveGroup]]}
             alwaysOpen
             className="obs-accordion"
           >

--- a/src/lib/components/obs-list/ObsList.js
+++ b/src/lib/components/obs-list/ObsList.js
@@ -298,9 +298,7 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
   });
 
   const obsList = enableGroups ? (
-    <Accordion className="obs-group-accordion" flush alwaysOpen>
-      {groupList}
-    </Accordion>
+    <>{groupList}</>
   ) : (
     _.map(
       _.sortBy(obsCols, (o) => _.lowerCase(o.name)),

--- a/src/scss/components/accordions.scss
+++ b/src/scss/components/accordions.scss
@@ -30,3 +30,8 @@
     color: #0c63e4;
   }
 }
+
+.obs-group-accordion-body {
+  @extend .accordion-flush;
+  padding: 0;
+}


### PR DESCRIPTION
fixes #94 
remove `expandedItems` variable
use only `active` to track expanded obs accordions