### PR TITLE
refactor continous obs bins

### DIFF
--- a/src/lib/components/obs-list/ObsItem.js
+++ b/src/lib/components/obs-list/ObsItem.js
@@ -273,33 +273,18 @@ function CategoricalItem({
 
 export function CategoricalObs({
   obs,
-  updateObs,
   toggleAll,
   toggleObs,
   showColor = true,
 }) {
   const dataset = useDataset();
   const { isSliced } = useFilteredData();
-  const dispatch = useDatasetDispatch();
   const totalCounts = _.sum(_.values(obs.value_counts));
   const min = _.min(_.values(obs.codes));
   const max = _.max(_.values(obs.codes));
 
   const obsHistograms = useObsHistogram(obs);
   const filteredObsData = useFilteredObsData(obs);
-
-  useEffect(() => {
-    if (dataset.selectedObs?.name === obs.name) {
-      const selectedObsData = _.omit(dataset.selectedObs, ["omit"]);
-      const obsData = _.omit(obs, ["omit"]);
-      if (!_.isEqual(selectedObsData, obsData)) {
-        // outdated selectedObs
-        dispatch({ type: "select.obs", obs: obs });
-      } else if (!_.isEqual(dataset.selectedObs.omit, obs.omit)) {
-        updateObs({ ...obs, omit: dataset.selectedObs.omit });
-      }
-    }
-  }, [dataset.selectedObs, dispatch, obs, obs.name, updateObs]);
 
   const getDataAtIndex = useCallback(
     (index) => {
@@ -424,55 +409,15 @@ function ObsContinuousStats({ obs }) {
   );
 }
 
-export function ContinuousObs({ obs, updateObs, toggleAll, toggleObs }) {
-  const ENDPOINT = "obs/bins";
-  const dataset = useDataset();
+// @TODO: add bin controls
+// @TODO: add histogram
+export function ContinuousObs({ obs, toggleAll, toggleObs }) {
   const { isSliced } = useFilteredData();
-  const dispatch = useDatasetDispatch();
-  const binnedObs = binContinuous(obs, _.min([N_BINS, obs.n_unique]));
-  const params = {
-    url: dataset.url,
-    obsCol: binnedObs.name,
-    thresholds: binnedObs.bins.thresholds,
-    nBins: binnedObs.bins.nBins,
-  };
-
-  const { fetchedData, isPending, serverError } = useFetch(ENDPOINT, params, {
-    refetchOnMount: false,
-  });
+  const totalCounts = _.sum(_.values(obs.value_counts));
+  const min = _.min(_.values(obs.codes));
+  const max = _.max(_.values(obs.codes));
 
   const filteredObsData = useFilteredObsData(obs);
-
-  const updatedObs = fetchedData && _.isMatch(obs, fetchedData);
-
-  useEffect(() => {
-    // Update ObsList obsCols with bin data
-    // after update -> re-render -> obs will already be updated
-    if (!isPending && !serverError && !_.isMatch(obs, fetchedData)) {
-      updateObs({
-        ...binnedObs,
-        ...fetchedData,
-        codesMap: _.invert(fetchedData.codes),
-      });
-    }
-  }, [binnedObs, fetchedData, isPending, obs, serverError, updateObs]);
-
-  useEffect(() => {
-    if (updatedObs && dataset.selectedObs?.name === obs.name) {
-      const selectedObsData = _.omit(dataset.selectedObs, ["omit"]);
-      const obsData = _.omit(obs, ["omit"]);
-      if (!_.isEqual(selectedObsData, obsData)) {
-        // outdated selectedObs
-        dispatch({ type: "select.obs", obs: obs });
-      } else if (!_.isEqual(dataset.selectedObs.omit, obs.omit)) {
-        updateObs({ ...obs, omit: dataset.selectedObs.omit });
-      }
-    }
-  }, [dataset.selectedObs, dispatch, obs, obs.name, updateObs, updatedObs]);
-
-  const totalCounts = _.sum(_.values(obs?.value_counts));
-  const min = _.min(_.values(obs?.codes));
-  const max = _.max(_.values(obs?.codes));
 
   const getDataAtIndex = (index) => {
     return {
@@ -496,27 +441,22 @@ export function ContinuousObs({ obs, updateObs, toggleAll, toggleObs }) {
 
   return (
     <>
-      {isPending && <LoadingLinear />}
-      {!serverError && updatedObs && (
-        <>
-          <ListGroup variant="flush" className="cherita-list">
-            <ListGroup.Item className="unstyled">
-              <ObsToolbar item={obs} onToggleAllObs={toggleAll} />
-            </ListGroup.Item>
-            <VirtualizedList
-              getDataAtIndex={getDataAtIndex}
-              count={obs.values.length}
-              ItemComponent={CategoricalItem}
-              totalCounts={totalCounts}
-              min={min}
-              max={max}
-              onChange={toggleObs}
-              showColor={false}
-            />
-          </ListGroup>
-          <ObsContinuousStats obs={obs} />
-        </>
-      )}
+      <ListGroup variant="flush" className="cherita-list">
+        <ListGroup.Item className="unstyled">
+          <ObsToolbar item={obs} onToggleAllObs={toggleAll} />
+        </ListGroup.Item>
+        <VirtualizedList
+          getDataAtIndex={getDataAtIndex}
+          count={obs.values.length}
+          ItemComponent={CategoricalItem}
+          totalCounts={totalCounts}
+          min={min}
+          max={max}
+          onChange={toggleObs}
+          showColor={false}
+        />
+      </ListGroup>
+      <ObsContinuousStats obs={obs} />
     </>
   );
 }

--- a/src/lib/components/obs-list/ObsItem.js
+++ b/src/lib/components/obs-list/ObsItem.js
@@ -7,7 +7,7 @@ import { Badge, Form, ListGroup } from "react-bootstrap";
 
 import { ObsToolbar } from "./ObsToolbar";
 import { COLOR_ENCODINGS, OBS_TYPES } from "../../constants/constants";
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import { useDataset } from "../../context/DatasetContext";
 import { useFilteredData } from "../../context/FilterContext";
 import { useColor } from "../../helpers/color-helper";
 import { Histogram } from "../../utils/Histogram";

--- a/src/lib/components/obs-list/ObsList.js
+++ b/src/lib/components/obs-list/ObsList.js
@@ -27,11 +27,11 @@ import { useFetch } from "../../utils/requests";
 const ObsAccordionToggle = ({ children, eventKey, handleAccordionToggle }) => {
   const { activeEventKey } = useContext(AccordionContext);
 
-  const decoratedOnClick = useAccordionButton(eventKey, () => {
-    handleAccordionToggle(eventKey);
-  });
-
   const isCurrentEventKey = (activeEventKey || []).includes(eventKey);
+
+  const decoratedOnClick = useAccordionButton(eventKey, () => {
+    handleAccordionToggle(eventKey, isCurrentEventKey);
+  });
 
   return (
     <div
@@ -54,7 +54,7 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
   const dispatch = useDatasetDispatch();
   const [enableGroups, setEnableGroups] = useState(enableObsGroups);
   const [obsCols, setObsCols] = useState(null);
-  const [active, setActive] = useState([]);
+  const [active, setActive] = useState([...[dataset.selectedObs?.name]]);
   const [params, setParams] = useState({ url: dataset.url });
   const obsGroups = useMemo(
     () => ({
@@ -124,13 +124,11 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
     });
   };
 
-  const handleAccordionToggle = (itemName) => {
-    if (active.includes(itemName)) {
+  const handleAccordionToggle = (itemName, isCurrentEventKey) => {
+    if (isCurrentEventKey) {
       _.delay(() => setActive((prev) => _.without(prev, itemName)), 250);
     } else {
-      setActive((prev) => {
-        return [...prev, itemName];
-      });
+      setActive((prev) => [...prev, itemName]);
     }
   };
 
@@ -320,7 +318,7 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
         ) : (
           <Accordion
             flush
-            defaultActiveKey={[active]}
+            defaultActiveKey={active}
             alwaysOpen
             className="obs-accordion"
           >

--- a/src/lib/components/obs-list/ObsList.js
+++ b/src/lib/components/obs-list/ObsList.js
@@ -118,12 +118,6 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
     }
   }, [dataset.selectedObs, dispatch, obsCols]);
 
-  const updateObs = (updatedObs) => {
-    setObsCols((o) => {
-      return { ...o, [updatedObs.name]: updatedObs };
-    });
-  };
-
   const handleAccordionToggle = (itemName, isCurrentEventKey) => {
     if (isCurrentEventKey) {
       _.delay(() => setActive((prev) => _.without(prev, itemName)), 250);
@@ -139,7 +133,7 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
     setObsCols((o) => {
       return { ...o, [item.name]: { ...item, omit: omit } };
     });
-    if (active === item.name) {
+    if (dataset.selectedObs?.name === item.name) {
       dispatch({ type: "select.obs", obs: { ...item, omit: omit } });
     }
   };
@@ -175,7 +169,7 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
     setObsCols((o) => {
       return { ...o, [item.name]: { ...item, omit: omit } };
     });
-    if (active === item.name) {
+    if (dataset.selectedObs?.name === item.name) {
       dispatch({ type: "select.obs", obs: { ...item, omit: omit } });
     }
   };
@@ -241,7 +235,6 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
                 <CategoricalObs
                   key={item.name}
                   obs={item}
-                  updateObs={updateObs}
                   toggleAll={() => toggleAll(item)}
                   toggleObs={(value) => toggleObs(item, value)}
                   toggleLabel={() => toggleLabel(item)}
@@ -253,7 +246,6 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
                 <ContinuousObs
                   key={item.name}
                   obs={item}
-                  updateObs={updateObs}
                   toggleAll={() => toggleAll(item)}
                   toggleObs={(value) => toggleObs(item, value)}
                   toggleLabel={() => toggleLabel(item)}

--- a/src/lib/components/obs-list/ObsList.js
+++ b/src/lib/components/obs-list/ObsList.js
@@ -306,6 +306,10 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
     )
   );
 
+  const defaultActiveGroup = enableGroups
+    ? `group-${_.findKey(obsGroups, (g) => g.includes(active?.[0]))}`
+    : null;
+
   if (!serverError) {
     return (
       <div className="position-relative h-100">
@@ -316,7 +320,7 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
         ) : (
           <Accordion
             flush
-            defaultActiveKey={active}
+            defaultActiveKey={[...active, ...[defaultActiveGroup]]}
             alwaysOpen
             className="obs-accordion"
           >

--- a/src/lib/components/obs-list/ObsList.js
+++ b/src/lib/components/obs-list/ObsList.js
@@ -298,9 +298,7 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
   });
 
   const obsList = enableGroups ? (
-    <Accordion className="obs-group-accordion" flush alwaysOpen>
-      {groupList}
-    </Accordion>
+    <>{groupList}</>
   ) : (
     _.map(
       _.sortBy(obsCols, (o) => _.lowerCase(o.name)),

--- a/src/scss/components/accordions.scss
+++ b/src/scss/components/accordions.scss
@@ -30,3 +30,8 @@
     color: #0c63e4;
   }
 }
+
+.obs-group-accordion-body {
+  @extend .accordion-flush;
+  padding: 0;
+}


### PR DESCRIPTION
Removes request for continuous obs bins in `ObsItem`, expects bin data to be provided by `ObsList`
Requires backend to return bins on obs metadata request (https://github.com/haniffalab/cherita-flask-api/pull/46)
Simplifies obs items :)
Fixes #98 and #61 