### PR TITLE
fix scatterplot embedding loading

### DIFF
--- a/src/lib/components/scatterplot/Scatterplot.js
+++ b/src/lib/components/scatterplot/Scatterplot.js
@@ -16,6 +16,8 @@ import { EditableGeoJsonLayer } from "@nebula.gl/layers";
 import _ from "lodash";
 import { Alert } from "react-bootstrap";
 
+import { SpatialControls } from "./SpatialControls";
+import { Toolbox } from "./Toolbox";
 import {
   COLOR_ENCODINGS,
   OBS_TYPES,
@@ -31,8 +33,6 @@ import { Legend } from "../../utils/Legend";
 import { LoadingLinear, LoadingSpinner } from "../../utils/LoadingIndicators";
 import { formatNumerical } from "../../utils/string";
 import { useLabelObsData } from "../../utils/zarrData";
-import { SpatialControls } from "./SpatialControls";
-import { Toolbox } from "./Toolbox";
 
 window.deck.log.level = 1;
 

--- a/src/lib/helpers/zarr-helper.js
+++ b/src/lib/helpers/zarr-helper.js
@@ -35,8 +35,7 @@ const fetchDataFromZarr = async (url, path, s, opts) => {
 };
 
 export const useZarr = (
-  { url, path },
-  s = null,
+  { url, path, s = null },
   options = GET_OPTIONS,
   opts = {}
 ) => {

--- a/src/lib/utils/zarrData.js
+++ b/src/lib/utils/zarrData.js
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 
 import _ from "lodash";
+import { slice } from "zarr";
 
 import { OBS_TYPES } from "../constants/constants";
 import { useDataset } from "../context/DatasetContext";
 import { GET_OPTIONS, useZarr, useMultipleZarr } from "../helpers/zarr-helper";
 
+// @TODO: support specifying slice to load from context
 export const useObsmData = (obsm = null) => {
   const dataset = useDataset();
 
@@ -14,13 +16,18 @@ export const useObsmData = (obsm = null) => {
   const [obsmParams, setObsmParams] = useState({
     url: dataset.url,
     path: "obsm/" + obsm,
+    s: [null, slice(null, 2)], // load only [:, :2]
   });
 
   useEffect(() => {
-    setObsmParams({ url: dataset.url, path: "obsm/" + obsm });
+    setObsmParams({
+      url: dataset.url,
+      path: "obsm/" + obsm,
+      s: [null, slice(null, 2)],
+    });
   }, [dataset.url, obsm]);
 
-  return useZarr(obsmParams, null, GET_OPTIONS, { enabled: !!obsm });
+  return useZarr(obsmParams, GET_OPTIONS, { enabled: !!obsm });
 };
 
 const meanData = (_i, data) => {
@@ -95,7 +102,7 @@ export const useObsData = (obs = null) => {
     });
   }, [dataset.url, obs]);
 
-  return useZarr(obsParams, null, GET_OPTIONS, { enabled: !!obs });
+  return useZarr(obsParams, GET_OPTIONS, { enabled: !!obs });
 };
 
 export const useLabelObsData = () => {

--- a/src/scss/cherita.scss
+++ b/src/scss/cherita.scss
@@ -14,7 +14,7 @@ $prefix: "bs-" !default;
   height: 100%;
   width: 100%;
   display: flex;
-  z-index: 1;
+  z-index: 2;
   opacity: 0.75;
   position: absolute;
   justify-content: center;


### PR DESCRIPTION
fetch only the first 2 dims of the selected obsm to avoid loading any potential additional chunks
simplify `useZarr` params to match `useMultipleZarr`
set the loading-spinner to a higher z-index to display on top of the scatterplot

Fixes #103 