### PR TITLE
Scatterplot navigation options (responsive)

### DIFF
--- a/sites/demo/src/components/Footer.js
+++ b/sites/demo/src/components/Footer.js
@@ -3,7 +3,7 @@ import Navbar from "react-bootstrap/Navbar";
 export default function Footer() {
   return (
     <footer>
-      <Navbar bg="secondary" data-bs-theme="dark">
+      <Navbar bg="secondary" variant="dark">
         <Container fluid>
           <Navbar.Brand href="#">Footer</Navbar.Brand>
         </Container>

--- a/sites/demo/src/components/Header.js
+++ b/sites/demo/src/components/Header.js
@@ -6,7 +6,7 @@ import { Link } from "react-router-dom";
 export default function Header() {
   return (
     <header>
-      <Navbar bg="primary" data-bs-theme="dark">
+      <Navbar bg="primary" variant="dark">
         <Container fluid>
           <Navbar.Brand href="#">Demo</Navbar.Brand>
           <Nav className="me-auto">
@@ -38,7 +38,7 @@ export default function Header() {
               <NavDropdown.Item as={Link} to="plots">
                 Plots
               </NavDropdown.Item>
-            </NavDropdown>            
+            </NavDropdown>
           </Nav>
         </Container>
       </Navbar>

--- a/sites/demo/src/containers/DotplotDemo.js
+++ b/sites/demo/src/containers/DotplotDemo.js
@@ -1,12 +1,14 @@
 import React, { useState } from "react";
 
+import { faList, faSearch, faSliders } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   DatasetProvider,
   Dotplot,
   DotplotControls,
+  OffcanvasControls,
   OffcanvasObs,
   OffcanvasVars,
-  OffcanvasControls,
 } from "@haniffalab/cherita-react";
 import Container from "react-bootstrap/Container";
 import Nav from "react-bootstrap/Nav";
@@ -16,32 +18,37 @@ export default function DotplotDemo(props) {
   const [showObs, setShowObs] = useState(false);
   const [showVars, setShowVars] = useState(false);
   const [showControls, setShowControls] = useState(false);
-
-  const handleCloseObs = () => setShowObs(false);
-  const handleShowObs = () => setShowObs(true);
-  const handleCloseVars = () => setShowVars(false);
-  const handleShowVars = () => setShowVars(true);
-  const handleCloseControls = () => setShowControls(false);
-  const handleShowControls = () => setShowControls(true);
   return (
     <Container>
       <div className="cherita-container">
         <DatasetProvider {...props}>
-          <Navbar expand="lg" bg="primary" className="cherita-navbar">
+          <Navbar
+            expand="lg"
+            bg="primary"
+            variant="dark"
+            className="cherita-navbar"
+          >
             <Container fluid>
               <Navbar.Toggle aria-controls="navbarScroll" />
               <Navbar.Collapse id="navbarScroll">
-                <Nav className="me-auto my-2 my-lg-0" navbarScroll>
-                  <Nav.Item>
-                    <Nav.Link onClick={handleShowObs}>Categories</Nav.Link>
+                <Nav navbarScroll>
+                  <Nav.Item className="me-2">
+                    <Nav.Link onClick={() => setShowObs(true)}>
+                      <FontAwesomeIcon icon={faList} className="me-2" />
+                      Explore Categories
+                    </Nav.Link>
                   </Nav.Item>
-                  <Nav.Item>
-                    <Nav.Link onClick={handleShowVars}>Features</Nav.Link>
+                  <Nav.Item className="me-2">
+                    <Nav.Link onClick={() => setShowVars(true)}>
+                      <FontAwesomeIcon icon={faSearch} className="me-2" />
+                      Search Genes
+                    </Nav.Link>
                   </Nav.Item>
-                </Nav>
-                <Nav className="d-flex">
-                  <Nav.Item>
-                    <Nav.Link onClick={handleShowControls}>Controls</Nav.Link>
+                  <Nav.Item className="me-2">
+                    <Nav.Link onClick={() => setShowControls(true)}>
+                      <FontAwesomeIcon icon={faSliders} className="me-2" />
+                      Controls
+                    </Nav.Link>
                   </Nav.Item>
                 </Nav>
               </Navbar.Collapse>
@@ -50,15 +57,14 @@ export default function DotplotDemo(props) {
           <div className="cherita-container-plot">
             <Dotplot />
           </div>
-          <OffcanvasObs
-            show={showObs}
-            handleClose={handleCloseObs}
-            showColor={false}
+          <OffcanvasObs show={showObs} handleClose={() => setShowObs(false)} />
+          <OffcanvasVars
+            show={showVars}
+            handleClose={() => setShowVars(false)}
           />
-          <OffcanvasVars show={showVars} handleClose={handleCloseVars} />
           <OffcanvasControls
             show={showControls}
-            handleClose={handleCloseControls}
+            handleClose={() => setShowControls(false)}
             Controls={DotplotControls}
           />
         </DatasetProvider>

--- a/sites/demo/src/containers/ScatterplotDemo.js
+++ b/sites/demo/src/containers/ScatterplotDemo.js
@@ -7,6 +7,7 @@ import {
   OffcanvasVars,
   Scatterplot,
   ScatterplotControls,
+  SELECTION_MODES,
 } from "@haniffalab/cherita-react";
 import Container from "react-bootstrap/Container";
 
@@ -30,7 +31,7 @@ export default function ScatterplotDemo(props) {
           <OffcanvasVars
             show={showVars}
             handleClose={() => setShowVars(false)}
-            mode="single"
+            mode={SELECTION_MODES.SINGLE}
           />
           <OffcanvasControls
             show={showControls}

--- a/sites/demo/src/containers/ScatterplotDemo.js
+++ b/sites/demo/src/containers/ScatterplotDemo.js
@@ -20,12 +20,17 @@ export default function ScatterplotDemo(props) {
       <div className="cherita-container">
         <DatasetProvider {...props}>
           <div className="cherita-container-scatterplot">
-            <Scatterplot setShowObs={setShowObs} setShowVars={setShowVars} />
+            <Scatterplot
+              setShowObs={setShowObs}
+              setShowVars={setShowVars}
+              isFullscreen={false}
+            />
           </div>
           <OffcanvasObs show={showObs} handleClose={() => setShowObs(false)} />
           <OffcanvasVars
             show={showVars}
             handleClose={() => setShowVars(false)}
+            mode="single"
           />
           <OffcanvasControls
             show={showControls}

--- a/sites/demo/src/containers/ScatterplotDemo.js
+++ b/sites/demo/src/containers/ScatterplotDemo.js
@@ -2,72 +2,34 @@ import React, { useState } from "react";
 
 import {
   DatasetProvider,
+  OffcanvasControls,
+  OffcanvasObs,
+  OffcanvasVars,
   Scatterplot,
   ScatterplotControls,
-  SELECTION_MODES,
-  OffcanvasObs,
-  OffcanvasObsm,
-  OffcanvasVars,
-  OffcanvasControls,
 } from "@haniffalab/cherita-react";
 import Container from "react-bootstrap/Container";
-import Nav from "react-bootstrap/Nav";
-import Navbar from "react-bootstrap/Navbar";
 
 export default function ScatterplotDemo(props) {
   const [showObs, setShowObs] = useState(false);
-  const [showObsm, setShowObsm] = useState(false);
   const [showVars, setShowVars] = useState(false);
   const [showControls, setShowControls] = useState(false);
 
-  const handleCloseObs = () => setShowObs(false);
-  const handleShowObs = () => setShowObs(true);
-  const handleCloseObsm = () => setShowObsm(false);
-  const handleShowObsm = () => setShowObsm(true);
-  const handleCloseVars = () => setShowVars(false);
-  const handleShowVars = () => setShowVars(true);
-  const handleCloseControls = () => setShowControls(false);
-  const handleShowControls = () => setShowControls(true);
   return (
     <Container>
       <div className="cherita-container">
         <DatasetProvider {...props}>
-          <Navbar expand="lg" bg="primary" className="cherita-navbar">
-            <Container fluid>
-              <Navbar.Toggle aria-controls="navbarScroll" />
-              <Navbar.Collapse id="navbarScroll">
-                <Nav className="me-auto my-2 my-lg-0" navbarScroll>
-                  <Nav.Item>
-                    <Nav.Link onClick={handleShowObs}>Categories</Nav.Link>
-                  </Nav.Item>
-                  <Nav.Item>
-                    <Nav.Link onClick={handleShowVars}>Features</Nav.Link>
-                  </Nav.Item>
-                  <Nav.Item>
-                    <Nav.Link onClick={handleShowObsm}>Embedding</Nav.Link>
-                  </Nav.Item>
-                </Nav>
-                <Nav className="d-flex">
-                  <Nav.Item>
-                    <Nav.Link onClick={handleShowControls}>Controls</Nav.Link>
-                  </Nav.Item>
-                </Nav>
-              </Navbar.Collapse>
-            </Container>
-          </Navbar>
           <div className="cherita-container-scatterplot">
-            <Scatterplot />
+            <Scatterplot setShowObs={setShowObs} setShowVars={setShowVars} />
           </div>
-          <OffcanvasObs show={showObs} handleClose={handleCloseObs} />
-          <OffcanvasObsm show={showObsm} handleClose={handleCloseObsm} />
+          <OffcanvasObs show={showObs} handleClose={() => setShowObs(false)} />
           <OffcanvasVars
             show={showVars}
-            handleClose={handleCloseVars}
-            mode={SELECTION_MODES.SINGLE}
+            handleClose={() => setShowVars(false)}
           />
           <OffcanvasControls
             show={showControls}
-            handleClose={handleCloseControls}
+            handleClose={() => setShowControls(false)}
             Controls={ScatterplotControls}
           />
         </DatasetProvider>

--- a/src/lib/components/full-page/FullPage.js
+++ b/src/lib/components/full-page/FullPage.js
@@ -98,6 +98,7 @@ export function FullPage({
           <OffcanvasVars
             show={showVars}
             handleClose={() => setShowVars(false)}
+            mode={varMode}
           />
           <OffcanvasControls
             show={showControls}
@@ -116,7 +117,7 @@ export function FullPage({
 
 export function FullPageScatterplot(props) {
   return (
-    <FullPage {...props}>
+    <FullPage {...props} varMode={SELECTION_MODES.SINGLE}>
       {({ setShowObs, setShowVars }) => (
         <Scatterplot
           setShowObs={setShowObs}

--- a/src/lib/components/full-page/FullPage.js
+++ b/src/lib/components/full-page/FullPage.js
@@ -118,7 +118,11 @@ export function FullPageScatterplot(props) {
   return (
     <FullPage {...props}>
       {({ setShowObs, setShowVars }) => (
-        <Scatterplot setShowObs={setShowObs} setShowVars={setShowVars} />
+        <Scatterplot
+          setShowObs={setShowObs}
+          setShowVars={setShowVars}
+          isFullscreen={true}
+        />
       )}
     </FullPage>
   );

--- a/src/lib/components/full-page/FullPage.js
+++ b/src/lib/components/full-page/FullPage.js
@@ -1,6 +1,17 @@
 import React, { useEffect, useRef, useState } from "react";
 
-import { Card, Container, Modal, Nav, Navbar } from "react-bootstrap";
+import { faLayerGroup, faSearch } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import {
+  Card,
+  Container,
+  Modal,
+  OverlayTrigger,
+  Tooltip,
+} from "react-bootstrap";
+import Button from "react-bootstrap/Button";
+import ButtonGroup from "react-bootstrap/ButtonGroup";
 
 import { SELECTION_MODES, VIOLIN_MODES } from "../../constants/constants";
 import { DatasetProvider } from "../../context/DatasetContext";
@@ -33,6 +44,8 @@ export function FullPage({
   const [showVars, setShowVars] = useState(false);
   const [showControls, setShowControls] = useState(false);
   const [showModal, setShowModal] = useState(false);
+  const showObsBtn = useMediaQuery("(max-width: 991.98px)");
+  const showVarsBtn = useMediaQuery("(max-width: 1199.98px)");
 
   useEffect(() => {
     const updateDimensions = () => {
@@ -69,32 +82,42 @@ export function FullPage({
           className="d-flex g-0"
           style={{ height: appDimensions.height }}
         >
-          <Navbar expand="sm" bg="primary" className="cherita-navbar">
-            <div className="container-fluid">
-              <Navbar.Toggle aria-controls="navbarScroll" />
-              <Navbar.Collapse id="navbarScroll">
-                <Nav className="me-auto my-0" navbarScroll>
-                  <Nav.Item className="d-block d-lg-none">
-                    <Nav.Link onClick={() => setShowObs(true)}>
-                      Observations
-                    </Nav.Link>
-                  </Nav.Item>
-                  <Nav.Item>
-                    <Nav.Link onClick={() => setShowVars(true)}>
-                      Features
-                    </Nav.Link>
-                  </Nav.Item>
-                </Nav>
-                <Nav className="d-flex">
-                  <Nav.Item>
-                    <Nav.Link onClick={() => setShowControls(true)}>
-                      Controls
-                    </Nav.Link>
-                  </Nav.Item>
-                </Nav>
-              </Navbar.Collapse>
-            </div>
-          </Navbar>
+          <div className="cherita-navbar">
+            <ButtonGroup vertical className="w-100 mb-1">
+              {showObsBtn && (
+                <OverlayTrigger
+                  placement="left"
+                  overlay={
+                    <Tooltip id="tooltip-obs">Browse categories</Tooltip>
+                  }
+                >
+                  <Button
+                    onClick={() => setShowObs(true)}
+                    className={
+                      showObsBtn && !showVarsBtn ? "rounded" : "rounded-top"
+                    }
+                  >
+                    <FontAwesomeIcon icon={faLayerGroup} />
+                  </Button>
+                </OverlayTrigger>
+              )}
+              {showVarsBtn && (
+                <OverlayTrigger
+                  placement="left"
+                  overlay={<Tooltip id="tooltip-vars">Search features</Tooltip>}
+                >
+                  <Button
+                    onClick={() => setShowVars(true)}
+                    className={
+                      showVarsBtn && !showObsBtn ? "rounded" : "rounded-bottom"
+                    }
+                  >
+                    <FontAwesomeIcon icon={faSearch} />
+                  </Button>
+                </OverlayTrigger>
+              )}
+            </ButtonGroup>
+          </div>
           <div className="cherita-app-obs modern-scrollbars border-end h-100">
             <ObsColsList {...props} />
           </div>

--- a/src/lib/components/full-page/FullPage.js
+++ b/src/lib/components/full-page/FullPage.js
@@ -1,17 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 
-import { faLayerGroup, faSearch } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import useMediaQuery from "@mui/material/useMediaQuery";
-import {
-  Card,
-  Container,
-  Modal,
-  OverlayTrigger,
-  Tooltip,
-} from "react-bootstrap";
-import Button from "react-bootstrap/Button";
-import ButtonGroup from "react-bootstrap/ButtonGroup";
+import { Card, Container, Modal } from "react-bootstrap";
 
 import { SELECTION_MODES, VIOLIN_MODES } from "../../constants/constants";
 import { DatasetProvider } from "../../context/DatasetContext";
@@ -44,8 +33,6 @@ export function FullPage({
   const [showVars, setShowVars] = useState(false);
   const [showControls, setShowControls] = useState(false);
   const [showModal, setShowModal] = useState(false);
-  const showObsBtn = useMediaQuery("(max-width: 991.98px)");
-  const showVarsBtn = useMediaQuery("(max-width: 1199.98px)");
 
   useEffect(() => {
     const updateDimensions = () => {
@@ -82,46 +69,15 @@ export function FullPage({
           className="d-flex g-0"
           style={{ height: appDimensions.height }}
         >
-          <div className="cherita-navbar">
-            <ButtonGroup vertical className="w-100 mb-1">
-              {showObsBtn && (
-                <OverlayTrigger
-                  placement="left"
-                  overlay={
-                    <Tooltip id="tooltip-obs">Browse categories</Tooltip>
-                  }
-                >
-                  <Button
-                    onClick={() => setShowObs(true)}
-                    className={
-                      showObsBtn && !showVarsBtn ? "rounded" : "rounded-top"
-                    }
-                  >
-                    <FontAwesomeIcon icon={faLayerGroup} />
-                  </Button>
-                </OverlayTrigger>
-              )}
-              {showVarsBtn && (
-                <OverlayTrigger
-                  placement="left"
-                  overlay={<Tooltip id="tooltip-vars">Search features</Tooltip>}
-                >
-                  <Button
-                    onClick={() => setShowVars(true)}
-                    className={
-                      showVarsBtn && !showObsBtn ? "rounded" : "rounded-bottom"
-                    }
-                  >
-                    <FontAwesomeIcon icon={faSearch} />
-                  </Button>
-                </OverlayTrigger>
-              )}
-            </ButtonGroup>
-          </div>
           <div className="cherita-app-obs modern-scrollbars border-end h-100">
             <ObsColsList {...props} />
           </div>
-          <div className="cherita-app-canvas flex-grow-1">{children}</div>
+          <div className="cherita-app-canvas flex-grow-1">
+            {children({
+              setShowObs,
+              setShowVars,
+            })}
+          </div>
           <div className="cherita-app-sidebar p-3">
             <Card>
               <Card.Body className="d-flex flex-column p-0">
@@ -161,7 +117,9 @@ export function FullPage({
 export function FullPageScatterplot(props) {
   return (
     <FullPage {...props}>
-      <Scatterplot />
+      {({ setShowObs, setShowVars }) => (
+        <Scatterplot setShowObs={setShowObs} setShowVars={setShowVars} />
+      )}
     </FullPage>
   );
 }

--- a/src/lib/components/full-page/FullPagePseudospatial.js
+++ b/src/lib/components/full-page/FullPagePseudospatial.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 
 import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Button, Card, Container, Modal, Nav, Navbar } from "react-bootstrap";
+import { Button, Card, Container, Modal } from "react-bootstrap";
 
 import { SELECTION_MODES } from "../../constants/constants";
 import { DatasetProvider } from "../../context/DatasetContext";
@@ -72,36 +72,15 @@ export function FullPage({
           className="d-flex g-0"
           style={{ height: appDimensions.height }}
         >
-          <Navbar expand="sm" bg="primary" className="cherita-navbar">
-            <div className="container-fluid">
-              <Navbar.Toggle aria-controls="navbarScroll" />
-              <Navbar.Collapse id="navbarScroll">
-                <Nav className="me-auto my-0" navbarScroll>
-                  <Nav.Item className="d-block d-lg-none">
-                    <Nav.Link onClick={() => setShowObs(true)}>
-                      Observations
-                    </Nav.Link>
-                  </Nav.Item>
-                  <Nav.Item>
-                    <Nav.Link onClick={() => setShowVars(true)}>
-                      Features
-                    </Nav.Link>
-                  </Nav.Item>
-                </Nav>
-                <Nav className="d-flex">
-                  <Nav.Item>
-                    <Nav.Link onClick={() => setShowControls(true)}>
-                      Controls
-                    </Nav.Link>
-                  </Nav.Item>
-                </Nav>
-              </Navbar.Collapse>
-            </div>
-          </Navbar>
           <div className="cherita-app-obs modern-scrollbars border-end h-100">
             <ObsColsList {...props} />
           </div>
-          <div className="cherita-app-canvas flex-grow-1">{children}</div>
+          <div className="cherita-app-canvas flex-grow-1">
+            {children({
+              setShowObs,
+              setShowVars,
+            })}
+          </div>
           <div className="cherita-app-sidebar p-3">
             <Card>
               <Card.Header className="d-flex justify-content-evenly align-items-center">
@@ -170,7 +149,9 @@ export function FullPage({
 export function FullPagePseudospatial(props) {
   return (
     <FullPage {...props}>
-      <Scatterplot />
+      {({ setShowObs, setShowVars }) => (
+        <Scatterplot setShowObs={setShowObs} setShowVars={setShowVars} />
+      )}
     </FullPage>
   );
 }

--- a/src/lib/components/full-page/FullPagePseudospatial.js
+++ b/src/lib/components/full-page/FullPagePseudospatial.js
@@ -124,6 +124,7 @@ export function FullPage({
           <OffcanvasVars
             show={showVars}
             handleClose={() => setShowVars(false)}
+            mode={varMode}
           />
           <OffcanvasControls
             show={showControls}
@@ -148,7 +149,7 @@ export function FullPage({
 
 export function FullPagePseudospatial(props) {
   return (
-    <FullPage {...props}>
+    <FullPage {...props} varMode={SELECTION_MODES.SINGLE}>
       {({ setShowObs, setShowVars }) => (
         <Scatterplot
           setShowObs={setShowObs}

--- a/src/lib/components/full-page/FullPagePseudospatial.js
+++ b/src/lib/components/full-page/FullPagePseudospatial.js
@@ -150,7 +150,11 @@ export function FullPagePseudospatial(props) {
   return (
     <FullPage {...props}>
       {({ setShowObs, setShowVars }) => (
-        <Scatterplot setShowObs={setShowObs} setShowVars={setShowVars} />
+        <Scatterplot
+          setShowObs={setShowObs}
+          setShowVars={setShowVars}
+          isFullscreen={true}
+        />
       )}
     </FullPage>
   );

--- a/src/lib/components/offcanvas/index.js
+++ b/src/lib/components/offcanvas/index.js
@@ -10,7 +10,7 @@ import { VarNamesList } from "../var-list/VarList";
 
 export function OffcanvasObs({ show, handleClose, ...props }) {
   return (
-    <Offcanvas show={show} onHide={handleClose} scroll={true} backdrop={false}>
+    <Offcanvas show={show} onHide={handleClose} scroll={true}>
       <Offcanvas.Header closeButton>
         <Offcanvas.Title>Categories</Offcanvas.Title>
       </Offcanvas.Header>

--- a/src/lib/components/scatterplot/Scatterplot.js
+++ b/src/lib/components/scatterplot/Scatterplot.js
@@ -45,7 +45,7 @@ const INITIAL_VIEW_STATE = {
   bearing: 0,
 };
 
-export function Scatterplot({ radius = 30 }) {
+export function Scatterplot({ radius = 30, setShowObs, setShowVars }) {
   const dataset = useDataset();
   const { obsIndices, valueMin, valueMax, slicedLength } = useFilteredData();
   const dispatch = useDatasetDispatch();
@@ -394,6 +394,8 @@ export function Scatterplot({ radius = 30 }) {
           resetBounds={() => setViewState(getBounds())}
           increaseZoom={() => setViewState((v) => ({ ...v, zoom: v.zoom + 1 }))}
           decreaseZoom={() => setViewState((v) => ({ ...v, zoom: v.zoom - 1 }))}
+          setShowObs={setShowObs}
+          setShowVars={setShowVars}
         />
         <div className="cherita-spatial-footer">
           <div className="cherita-toolbox-footer">

--- a/src/lib/components/scatterplot/Scatterplot.js
+++ b/src/lib/components/scatterplot/Scatterplot.js
@@ -45,7 +45,12 @@ const INITIAL_VIEW_STATE = {
   bearing: 0,
 };
 
-export function Scatterplot({ radius = 30, setShowObs, setShowVars }) {
+export function Scatterplot({
+  radius = 30,
+  setShowObs,
+  setShowVars,
+  isFullscreen = false,
+}) {
   const dataset = useDataset();
   const { obsIndices, valueMin, valueMax, slicedLength } = useFilteredData();
   const dispatch = useDatasetDispatch();
@@ -396,6 +401,7 @@ export function Scatterplot({ radius = 30, setShowObs, setShowVars }) {
           decreaseZoom={() => setViewState((v) => ({ ...v, zoom: v.zoom - 1 }))}
           setShowObs={setShowObs}
           setShowVars={setShowVars}
+          isFullscreen={isFullscreen}
         />
         <div className="cherita-spatial-footer">
           <div className="cherita-toolbox-footer">

--- a/src/lib/components/scatterplot/SpatialControls.js
+++ b/src/lib/components/scatterplot/SpatialControls.js
@@ -43,6 +43,7 @@ export function SpatialControls({
   decreaseZoom,
   setShowObs,
   setShowVars,
+  isFullscreen,
 }) {
   const dataset = useDataset();
   const dispatch = useDatasetDispatch();
@@ -50,8 +51,11 @@ export function SpatialControls({
 
   const handleCloseControls = () => setShowControls(false);
   const handleShowControls = () => setShowControls(true);
-  const showObsBtn = useMediaQuery("(max-width: 991.98px)");
-  const showVarsBtn = useMediaQuery("(max-width: 1199.98px)");
+
+  const LgBreakpoint = useMediaQuery("(max-width: 991.98px)");
+  const XlBreakpoint = useMediaQuery("(max-width: 1199.98px)");
+  const showObsBtn = isFullscreen ? LgBreakpoint : true;
+  const showVarsBtn = isFullscreen ? XlBreakpoint : true;
 
   const onSelect = (eventKey, event) => {
     switch (eventKey) {
@@ -116,31 +120,30 @@ export function SpatialControls({
 
   return (
     <div className="cherita-spatial-controls">
-      <ButtonGroup vertical className="w-100 mb-1">
-        {showObsBtn && (
-          <OverlayTrigger
-            placement="right"
-            overlay={<Tooltip id="tooltip-obs">Browse categories</Tooltip>}
-          >
-            <Button onClick={() => setShowObs(true)}>
-              <FontAwesomeIcon icon={faList} />
-            </Button>
-          </OverlayTrigger>
-        )}
-        {showVarsBtn && (
-          <OverlayTrigger
-            placement="right"
-            overlay={<Tooltip id="tooltip-vars">Search features</Tooltip>}
-          >
-            <Button onClick={() => setShowVars(true)}>
-              <FontAwesomeIcon icon={faSearch} />
-            </Button>
-          </OverlayTrigger>
-        )}
-        <Button onClick={handleShowControls}>
-          <FontAwesomeIcon icon={faSliders} />
-        </Button>
-      </ButtonGroup>
+      {(showObsBtn || showVarsBtn) && (
+        <ButtonGroup vertical className="w-100 mb-1">
+          {showObsBtn && (
+            <OverlayTrigger
+              placement="right"
+              overlay={<Tooltip id="tooltip-obs">Browse categories</Tooltip>}
+            >
+              <Button onClick={() => setShowObs(true)}>
+                <FontAwesomeIcon icon={faList} />
+              </Button>
+            </OverlayTrigger>
+          )}
+          {showVarsBtn && (
+            <OverlayTrigger
+              placement="right"
+              overlay={<Tooltip id="tooltip-vars">Search features</Tooltip>}
+            >
+              <Button onClick={() => setShowVars(true)}>
+                <FontAwesomeIcon icon={faSearch} />
+              </Button>
+            </OverlayTrigger>
+          )}
+        </ButtonGroup>
+      )}
       <ButtonGroup vertical className="w-100">
         <Button
           onClick={() => setMode(() => ViewMode)}
@@ -188,6 +191,9 @@ export function SpatialControls({
           </Dropdown.Menu>
         </Dropdown>
         {!!features?.features?.length && polygonControls}
+        <Button onClick={handleShowControls}>
+          <FontAwesomeIcon icon={faSliders} />
+        </Button>
       </ButtonGroup>
       <OffcanvasControls
         show={showControls}

--- a/src/lib/components/scatterplot/SpatialControls.js
+++ b/src/lib/components/scatterplot/SpatialControls.js
@@ -4,14 +4,17 @@ import {
   faCrosshairs,
   faDrawPolygon,
   faHand,
+  faList,
   faMinus,
   faPen,
   faPlus,
+  faSearch,
   faSliders,
   faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { JoinInner } from "@mui/icons-material";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import {
   DrawLineStringMode,
   DrawPolygonByDraggingMode,
@@ -20,6 +23,7 @@ import {
   ModifyMode,
   ViewMode,
 } from "@nebula.gl/edit-modes";
+import { OverlayTrigger, Tooltip } from "react-bootstrap";
 import Button from "react-bootstrap/Button";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import Dropdown from "react-bootstrap/Dropdown";
@@ -37,6 +41,8 @@ export function SpatialControls({
   resetBounds,
   increaseZoom,
   decreaseZoom,
+  setShowObs,
+  setShowVars,
 }) {
   const dataset = useDataset();
   const dispatch = useDatasetDispatch();
@@ -44,6 +50,8 @@ export function SpatialControls({
 
   const handleCloseControls = () => setShowControls(false);
   const handleShowControls = () => setShowControls(true);
+  const showObsBtn = useMediaQuery("(max-width: 991.98px)");
+  const showVarsBtn = useMediaQuery("(max-width: 1199.98px)");
 
   const onSelect = (eventKey, event) => {
     switch (eventKey) {
@@ -109,15 +117,26 @@ export function SpatialControls({
   return (
     <div className="cherita-spatial-controls">
       <ButtonGroup vertical className="w-100 mb-1">
-        <Button onClick={increaseZoom} title="Increase zoom">
-          <FontAwesomeIcon icon={faPlus} />
-        </Button>
-        <Button onClick={decreaseZoom} title="Decrease zoom">
-          <FontAwesomeIcon icon={faMinus} />
-        </Button>
-        <Button onClick={resetBounds} title="Reset zoom and center">
-          <FontAwesomeIcon icon={faCrosshairs} />
-        </Button>
+        {showObsBtn && (
+          <OverlayTrigger
+            placement="right"
+            overlay={<Tooltip id="tooltip-obs">Browse categories</Tooltip>}
+          >
+            <Button onClick={() => setShowObs(true)}>
+              <FontAwesomeIcon icon={faList} />
+            </Button>
+          </OverlayTrigger>
+        )}
+        {showVarsBtn && (
+          <OverlayTrigger
+            placement="right"
+            overlay={<Tooltip id="tooltip-vars">Search features</Tooltip>}
+          >
+            <Button onClick={() => setShowVars(true)}>
+              <FontAwesomeIcon icon={faSearch} />
+            </Button>
+          </OverlayTrigger>
+        )}
         <Button onClick={handleShowControls}>
           <FontAwesomeIcon icon={faSliders} />
         </Button>
@@ -129,6 +148,16 @@ export function SpatialControls({
           active={mode === ViewMode}
         >
           <FontAwesomeIcon icon={faHand} />
+        </Button>
+        <Button onClick={increaseZoom} title="Increase zoom">
+          <FontAwesomeIcon icon={faPlus} />
+        </Button>
+        <Button onClick={decreaseZoom} title="Decrease zoom">
+          <FontAwesomeIcon icon={faMinus} />
+        </Button>
+        <div className="border-bottom"></div> {/* Divider */}
+        <Button onClick={resetBounds} title="Reset zoom and center">
+          <FontAwesomeIcon icon={faCrosshairs} />
         </Button>
         <Dropdown
           as={ButtonGroup}

--- a/src/lib/components/scatterplot/Toolbox.js
+++ b/src/lib/components/scatterplot/Toolbox.js
@@ -1,7 +1,5 @@
 import React from "react";
 
-import { faDroplet } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Button, ButtonGroup, OverlayTrigger, Tooltip } from "react-bootstrap";
 
 import { formatNumerical } from "../../utils/string";
@@ -12,26 +10,6 @@ export function Toolbox({ mode, obsLength, slicedLength }) {
     <div className="cherita-toolbox">
       <ButtonGroup>
         <ObsmKeysList />
-        {mode && (
-          <OverlayTrigger
-            placement="top"
-            overlay={
-              <Tooltip id="tooltip-dropped-mode">
-                The color scale is currently set to {mode}
-              </Tooltip>
-            }
-          >
-            <Button
-              size="sm"
-              variant="primary"
-              style={{ cursor: "default" }}
-              aria-disabled="true"
-            >
-              <FontAwesomeIcon icon={faDroplet} className="me-1" /> {mode}
-            </Button>
-          </OverlayTrigger>
-        )}
-
         {(mode || !isNaN(obsLength)) &&
           (mode !== null &&
           !isNaN(slicedLength) &&

--- a/src/lib/utils/Legend.js
+++ b/src/lib/utils/Legend.js
@@ -1,11 +1,13 @@
 import React, { useMemo } from "react";
 
+import { faDroplet } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import _ from "lodash";
 
-import { formatNumerical, FORMATS } from "./string";
 import { COLOR_ENCODINGS } from "../constants/constants";
 import { useDataset } from "../context/DatasetContext";
 import { rgbToHex, useColor } from "../helpers/color-helper";
+import { formatNumerical, FORMATS } from "./string";
 
 export function Legend({
   isCategorical = false,
@@ -41,6 +43,7 @@ export function Legend({
       <div className="cherita-legend">
         <div className="gradient">
           <p className="small m-0 p-0">
+            <FontAwesomeIcon icon={faDroplet} className="me-1" />
             {(dataset.colorEncoding === COLOR_ENCODINGS.VAR
               ? dataset.selectedVar?.name
               : dataset.selectedObs?.name) + addText}
@@ -60,15 +63,13 @@ export function Legend({
     );
   } else {
     return (
-      <div className="cherita-legend">
-        <div className="gradient">
-          <p className="small m-0 p-0">
-            {dataset.colorEncoding === COLOR_ENCODINGS.OBS &&
-            dataset.selectedObs
-              ? dataset.selectedObs.name
-              : ""}
-          </p>
-        </div>
+      <div className="cherita-legend w-100 ">
+        <p className="m-0 p-0 text-end">
+          <FontAwesomeIcon icon={faDroplet} className="me-1" />
+          {dataset.colorEncoding === COLOR_ENCODINGS.OBS && dataset.selectedObs
+            ? dataset.selectedObs.name
+            : ""}
+        </p>
       </div>
     );
   }

--- a/src/lib/utils/Legend.js
+++ b/src/lib/utils/Legend.js
@@ -61,14 +61,15 @@ export function Legend({
         </div>
       </div>
     );
-  } else {
+  } else if (
+    dataset.colorEncoding === COLOR_ENCODINGS.OBS &&
+    dataset.selectedObs
+  ) {
     return (
-      <div className="cherita-legend w-100 ">
-        <p className="m-0 p-0 text-end">
-          <FontAwesomeIcon icon={faDroplet} className="me-1" />
-          {dataset.colorEncoding === COLOR_ENCODINGS.OBS && dataset.selectedObs
-            ? dataset.selectedObs.name
-            : ""}
+      <div className="cherita-legend categorical">
+        <p className="legend-text text-end m-0 p-0">
+          <FontAwesomeIcon icon={faDroplet} className="me-2" />
+          {dataset.selectedObs.name}
         </p>
       </div>
     );

--- a/src/scss/cherita.scss
+++ b/src/scss/cherita.scss
@@ -76,7 +76,7 @@ $prefix: "bs-" !default;
   bottom: 0;
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: end;
   flex-wrap: wrap;
   width: 100%;
   padding: 1rem;

--- a/src/scss/cherita.scss
+++ b/src/scss/cherita.scss
@@ -76,7 +76,7 @@ $prefix: "bs-" !default;
   bottom: 0;
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: center;
   flex-wrap: wrap;
   width: 100%;
   padding: 1rem;
@@ -103,6 +103,41 @@ $prefix: "bs-" !default;
 .cherita-legend {
   order: 2;
   width: 12rem;
+  color: #333;
+}
+
+.cherita-legend.categorical {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-left: 1rem;
+  flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  pointer-events: auto;
+  .legend-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+    display: inline-block;
+  }
+}
+
+@media (max-width: 600px) {
+  .cherita-spatial-footer {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .cherita-legend {
+    flex-direction: column;
+    align-items: center;
+    margin-top: 1rem;
+    padding: 0;
+  }
 }
 
 .cherita-accordion-active .accordion-button {

--- a/src/scss/cherita.scss
+++ b/src/scss/cherita.scss
@@ -73,15 +73,13 @@ $prefix: "bs-" !default;
 .cherita-spatial-footer {
   position: absolute;
   z-index: 10;
-  bottom: 1rem;
+  bottom: 0;
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
   flex-wrap: wrap;
   width: 100%;
-  padding-left: 1rem;
-  padding-right: 1rem;
-  padding-bottom: 1rem;
+  padding: 1rem;
   pointer-events: none;
 
   > * {

--- a/src/scss/components/layouts.scss
+++ b/src/scss/components/layouts.scss
@@ -4,11 +4,16 @@
 
 .cherita-app {
   .cherita-navbar {
+    @extend .m-3;
+    @extend .d-block;
+    @extend .d-xl-none;
+
     position: absolute;
-    z-index: 10;
-    top: 1rem;
-    right: 1rem;
-    width: 3rem;
+    z-index: 11;
+    top: 0;
+    left: 0;
+    right: 0;
+    border-radius: 0.25rem;
     @media (min-width: 992px) and (max-width: 1199px) {
       margin-left: calc(33.33333333% + 1rem) !important;
     }

--- a/src/scss/components/layouts.scss
+++ b/src/scss/components/layouts.scss
@@ -2,19 +2,16 @@
   position: relative;
 }
 
-.cherita-app .cherita-navbar {
-  @extend .m-3;
-  @extend .d-block;
-  @extend .d-xl-none;
-
-  position: absolute;
-  z-index: 11;
-  top: 0;
-  left: 0;
-  right: 0;
-  border-radius: 0.25rem;
-  @media (min-width: 992px) and (max-width: 1199px) {
-    margin-left: calc(33.33333333% + 1rem) !important;
+.cherita-app {
+  .cherita-navbar {
+    position: absolute;
+    z-index: 10;
+    top: 1rem;
+    right: 1rem;
+    width: 3rem;
+    @media (min-width: 992px) and (max-width: 1199px) {
+      margin-left: calc(33.33333333% + 1rem) !important;
+    }
   }
 }
 

--- a/src/scss/components/plots.scss
+++ b/src/scss/components/plots.scss
@@ -5,9 +5,3 @@
   left: 1rem;
   width: 3rem;
 }
-
-@media (max-width: 1199.98px) {
-  .cherita-spatial-controls {
-    top: 5rem;
-  }
-}

--- a/src/scss/components/plots.scss
+++ b/src/scss/components/plots.scss
@@ -4,4 +4,8 @@
   top: 1rem;
   left: 1rem;
   width: 3rem;
+  .btn {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }


### PR DESCRIPTION
# Description

This PR improves the navigation in the scatterplot component, by moving the navbar menu options in the vertical toolbar. 

Changes:
- Demo site header and footer cleanup
- Changes for consistency and simplification of navbar for DotplotDemo
- Removal of embedded navbar in <Scatterplot> <FulPage> and <FullpagePseudospatial> components
- Restore the backdrop feature in OffcanvasObs, so that when you click away from the sidebar it will close
- Showing of the ObsBtn and VarBtn in the spatial toolbar - conditional depending on the media query status.
- Removal of colour scale information from Toolbix, which is now incorporated into the Legend componet.
- CSS so that the legend will collapse under the Toolbox in mobile views. 

Fixes #111 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [x] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
