### PR TITLE
Refactor context

### DIFF
--- a/src/lib/components/dotplot/Dotplot.js
+++ b/src/lib/components/dotplot/Dotplot.js
@@ -4,42 +4,47 @@ import _ from "lodash";
 import { Alert } from "react-bootstrap";
 import Plot from "react-plotly.js";
 
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import { useDataset } from "../../context/DatasetContext";
 import { useFilteredData } from "../../context/FilterContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 import { LoadingSpinner } from "../../utils/LoadingIndicators";
 import { useDebouncedFetch } from "../../utils/requests";
 
 export function Dotplot() {
   const ENDPOINT = "dotplot";
   const dataset = useDataset();
+  const settings = useSettings();
   const { obsIndices, isSliced } = useFilteredData();
-  const dispatch = useDatasetDispatch();
-  const colorscale = useRef(dataset.controls.colorScale);
+  const dispatch = useSettingsDispatch();
+  const colorscale = useRef(settings.controls.colorScale);
   const [data, setData] = useState([]);
   const [layout, setLayout] = useState({});
   const [hasSelections, setHasSelections] = useState(false);
   const [params, setParams] = useState({
     url: dataset.url,
-    obsCol: dataset.selectedObs,
-    obsValues: !dataset.selectedObs?.omit.length
+    obsCol: settings.selectedObs,
+    obsValues: !settings.selectedObs?.omit.length
       ? null
       : _.difference(
-          _.values(dataset.selectedObs?.codes),
-          dataset.selectedObs?.omit
-        ).map((c) => dataset.selectedObs?.codesMap[c]),
-    varKeys: dataset.selectedMultiVar.map((i) =>
+          _.values(settings.selectedObs?.codes),
+          settings.selectedObs?.omit
+        ).map((c) => settings.selectedObs?.codesMap[c]),
+    varKeys: settings.selectedMultiVar.map((i) =>
       i.isSet ? { name: i.name, indices: i.vars.map((v) => v.index) } : i.index
     ),
     obsIndices: isSliced ? [...(obsIndices || [])] : null,
-    standardScale: dataset.controls.standardScale,
-    meanOnlyExpressed: dataset.controls.meanOnlyExpressed,
-    expressionCutoff: dataset.controls.expressionCutoff,
+    standardScale: settings.controls.standardScale,
+    meanOnlyExpressed: settings.controls.meanOnlyExpressed,
+    expressionCutoff: settings.controls.expressionCutoff,
     varNamesCol: dataset.varNamesCol,
   });
   // @TODO: set default scale
 
   useEffect(() => {
-    if (dataset.selectedObs && dataset.selectedMultiVar.length) {
+    if (settings.selectedObs && settings.selectedMultiVar.length) {
       setHasSelections(true);
     } else {
       setHasSelections(false);
@@ -48,32 +53,32 @@ export function Dotplot() {
       return {
         ...p,
         url: dataset.url,
-        obsCol: dataset.selectedObs,
-        obsValues: !dataset.selectedObs?.omit.length
+        obsCol: settings.selectedObs,
+        obsValues: !settings.selectedObs?.omit.length
           ? null
           : _.difference(
-              _.values(dataset.selectedObs?.codes),
-              dataset.selectedObs?.omit
-            ).map((c) => dataset.selectedObs?.codesMap[c]),
-        varKeys: dataset.selectedMultiVar.map((i) =>
+              _.values(settings.selectedObs?.codes),
+              settings.selectedObs?.omit
+            ).map((c) => settings.selectedObs?.codesMap[c]),
+        varKeys: settings.selectedMultiVar.map((i) =>
           i.isSet
             ? { name: i.name, indices: i.vars.map((v) => v.index) }
             : i.index
         ),
         obsIndices: isSliced ? [...(obsIndices || [])] : null,
-        standardScale: dataset.controls.standardScale,
-        meanOnlyExpressed: dataset.controls.meanOnlyExpressed,
-        expressionCutoff: dataset.controls.expressionCutoff,
+        standardScale: settings.controls.standardScale,
+        meanOnlyExpressed: settings.controls.meanOnlyExpressed,
+        expressionCutoff: settings.controls.expressionCutoff,
         varNamesCol: dataset.varNamesCol,
       };
     });
   }, [
     dataset.url,
-    dataset.selectedObs,
-    dataset.selectedMultiVar,
-    dataset.controls.standardScale,
-    dataset.controls.meanOnlyExpressed,
-    dataset.controls.expressionCutoff,
+    settings.selectedObs,
+    settings.selectedMultiVar,
+    settings.controls.standardScale,
+    settings.controls.meanOnlyExpressed,
+    settings.controls.expressionCutoff,
     dataset.varNamesCol,
     isSliced,
     obsIndices,
@@ -120,9 +125,9 @@ export function Dotplot() {
   ]);
 
   useEffect(() => {
-    colorscale.current = dataset.controls.colorScale;
+    colorscale.current = settings.controls.colorScale;
     updateColorscale(colorscale.current);
-  }, [dataset.controls.colorScale, updateColorscale]);
+  }, [settings.controls.colorScale, updateColorscale]);
 
   useEffect(() => {
     setLayout((l) => {
@@ -130,12 +135,12 @@ export function Dotplot() {
         ...l,
         coloraxis: {
           ...l.coloraxis,
-          cmin: dataset.controls.colorAxis.cmin,
-          cmax: dataset.controls.colorAxis.cmax,
+          cmin: settings.controls.colorAxis.cmin,
+          cmax: settings.controls.colorAxis.cmax,
         },
       };
     });
-  }, [dataset.controls.colorAxis.cmin, dataset.controls.colorAxis.cmax]);
+  }, [settings.controls.colorAxis.cmin, settings.controls.colorAxis.cmax]);
 
   if (!serverError) {
     if (hasSelections) {

--- a/src/lib/components/dotplot/DotplotControls.js
+++ b/src/lib/components/dotplot/DotplotControls.js
@@ -13,16 +13,19 @@ import Dropdown from "react-bootstrap/Dropdown";
 
 import { COLORSCALES } from "../../constants/colorscales";
 import { DOTPLOT_SCALES } from "../../constants/constants";
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 
 export function DotplotControls() {
-  const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
   const [controls, setControls] = useState({
-    expressionCutoff: dataset.controls.expressionCutoff,
+    expressionCutoff: settings.controls.expressionCutoff,
     colorAxis: {
-      cmin: dataset.controls.colorAxis.cmin,
-      cmax: dataset.controls.colorAxis.cmax,
+      cmin: settings.controls.colorAxis.cmin,
+      cmax: settings.controls.colorAxis.cmax,
     },
   });
 
@@ -30,21 +33,21 @@ export function DotplotControls() {
     setControls((c) => ({
       ...c,
       colorAxis: {
-        cmin: dataset.controls.colorAxis.cmin,
-        cmax: dataset.controls.colorAxis.cmax,
+        cmin: settings.controls.colorAxis.cmin,
+        cmax: settings.controls.colorAxis.cmax,
       },
-      expressionCutoff: dataset.controls.expressionCutoff,
+      expressionCutoff: settings.controls.expressionCutoff,
     }));
   }, [
-    dataset.controls.colorAxis.cmin,
-    dataset.controls.colorAxis.cmax,
-    dataset.controls.expressionCutoff,
+    settings.controls.colorAxis.cmin,
+    settings.controls.colorAxis.cmax,
+    settings.controls.expressionCutoff,
   ]);
 
   const colorScaleList = _.keys(COLORSCALES).map((key) => (
     <Dropdown.Item
       key={key}
-      active={dataset.controls.colorScale === key}
+      active={settings.controls.colorScale === key}
       onClick={() => {
         dispatch({
           type: "set.controls.colorScale",
@@ -59,7 +62,7 @@ export function DotplotControls() {
   const standardScaleList = _.values(DOTPLOT_SCALES).map((scale) => (
     <Dropdown.Item
       key={scale.value}
-      active={dataset.controls.scale.dotplot === scale}
+      active={settings.controls.scale.dotplot === scale}
       onClick={() => {
         dispatch({
           type: "set.controls.scale",
@@ -77,7 +80,7 @@ export function DotplotControls() {
       <ButtonGroup>
         <Dropdown>
           <Dropdown.Toggle id="dropdownColorscale" variant="light">
-            {dataset.controls.colorScale}
+            {settings.controls.colorScale}
           </Dropdown.Toggle>
           <Dropdown.Menu>{colorScaleList}</Dropdown.Menu>
         </Dropdown>
@@ -87,7 +90,7 @@ export function DotplotControls() {
           <InputGroup.Text>Standard scale</InputGroup.Text>
           <Dropdown>
             <Dropdown.Toggle id="dropdownStandardScale" variant="light">
-              {dataset.controls.scale.dotplot.name}
+              {settings.controls.scale.dotplot.name}
             </Dropdown.Toggle>
             <Dropdown.Menu>{standardScaleList}</Dropdown.Menu>
           </Dropdown>
@@ -98,11 +101,11 @@ export function DotplotControls() {
           id="toggleMeanOnlyExpressed"
           type="checkbox"
           variant="outline-primary"
-          checked={dataset.controls.meanOnlyExpressed}
+          checked={settings.controls.meanOnlyExpressed}
           onChange={() => {
             dispatch({
               type: "set.controls.meanOnlyExpressed",
-              meanOnlyExpressed: !dataset.controls.meanOnlyExpressed,
+              meanOnlyExpressed: !settings.controls.meanOnlyExpressed,
             });
           }}
         >
@@ -154,8 +157,8 @@ export function DotplotControls() {
             type="number"
             value={controls.colorAxis.cmin}
             step={0.1}
-            min={Math.min(dataset.controls.colorAxis.dmin, 0.0)}
-            max={dataset.controls.colorAxis.dmax}
+            min={Math.min(settings.controls.colorAxis.dmin, 0.0)}
+            max={settings.controls.colorAxis.dmax}
             onChange={(e) => {
               setControls({
                 ...controls,
@@ -171,12 +174,12 @@ export function DotplotControls() {
             value={controls.colorAxis.cmax}
             step={0.1}
             min={controls.colorAxis.cmin}
-            max={dataset.controls.colorAxis.dmax}
+            max={settings.controls.colorAxis.dmax}
             onChange={(e) => {
               if (
-                parseFloat(e.target.value) > dataset.controls.colorAxis.dmax
+                parseFloat(e.target.value) > settings.controls.colorAxis.dmax
               ) {
-                e.target.value = dataset.controls.colorAxis.dmax.toFixed(1);
+                e.target.value = settings.controls.colorAxis.dmax.toFixed(1);
               }
               setControls({
                 ...controls,
@@ -192,8 +195,8 @@ export function DotplotControls() {
             onClick={() => {
               dispatch({
                 type: "set.controls.colorAxis.crange",
-                cmin: dataset.controls.colorAxis.dmin,
-                cmax: dataset.controls.colorAxis.dmax,
+                cmin: settings.controls.colorAxis.dmin,
+                cmax: settings.controls.colorAxis.dmax,
               });
             }}
           >

--- a/src/lib/components/heatmap/Heatmap.js
+++ b/src/lib/components/heatmap/Heatmap.js
@@ -6,27 +6,29 @@ import Plot from "react-plotly.js";
 
 import { useDataset } from "../../context/DatasetContext";
 import { useFilteredData } from "../../context/FilterContext";
+import { useSettings } from "../../context/SettingsContext";
 import { LoadingSpinner } from "../../utils/LoadingIndicators";
 import { useDebouncedFetch } from "../../utils/requests";
 
 export function Heatmap() {
   const ENDPOINT = "heatmap";
   const dataset = useDataset();
+  const settings = useSettings();
   const { obsIndices, isSliced } = useFilteredData();
-  const colorscale = useRef(dataset.controls.colorScale);
+  const colorscale = useRef(settings.controls.colorScale);
   const [data, setData] = useState([]);
   const [layout, setLayout] = useState({});
   const [hasSelections, setHasSelections] = useState(false);
   const [params, setParams] = useState({
     url: dataset.url,
-    obsCol: dataset.selectedObs,
-    obsValues: !dataset.selectedObs?.omit.length
+    obsCol: settings.selectedObs,
+    obsValues: !settings.selectedObs?.omit.length
       ? null
       : _.difference(
-          _.values(dataset.selectedObs?.codes),
-          dataset.selectedObs?.omit
-        ).map((c) => dataset.selectedObs?.codesMap[c]),
-    varKeys: dataset.selectedMultiVar.map((i) =>
+          _.values(settings.selectedObs?.codes),
+          settings.selectedObs?.omit
+        ).map((c) => settings.selectedObs?.codesMap[c]),
+    varKeys: settings.selectedMultiVar.map((i) =>
       i.isSet ? { name: i.name, indices: i.vars.map((v) => v.index) } : i.index
     ),
     obsIndices: isSliced ? [...(obsIndices || [])] : null,
@@ -34,7 +36,7 @@ export function Heatmap() {
   });
 
   useEffect(() => {
-    if (dataset.selectedObs && dataset.selectedMultiVar.length) {
+    if (settings.selectedObs && settings.selectedMultiVar.length) {
       setHasSelections(true);
     } else {
       setHasSelections(false);
@@ -43,14 +45,14 @@ export function Heatmap() {
       return {
         ...p,
         url: dataset.url,
-        obsCol: dataset.selectedObs,
-        obsValues: !dataset.selectedObs?.omit.length
+        obsCol: settings.selectedObs,
+        obsValues: !settings.selectedObs?.omit.length
           ? null
           : _.difference(
-              _.values(dataset.selectedObs?.codes),
-              dataset.selectedObs?.omit
-            ).map((c) => dataset.selectedObs?.codesMap[c]),
-        varKeys: dataset.selectedMultiVar.map((i) =>
+              _.values(settings.selectedObs?.codes),
+              settings.selectedObs?.omit
+            ).map((c) => settings.selectedObs?.codesMap[c]),
+        varKeys: settings.selectedMultiVar.map((i) =>
           i.isSet
             ? { name: i.name, indices: i.vars.map((v) => v.index) }
             : i.index
@@ -60,8 +62,8 @@ export function Heatmap() {
       };
     });
   }, [
-    dataset.selectedMultiVar,
-    dataset.selectedObs,
+    settings.selectedMultiVar,
+    settings.selectedObs,
     dataset.url,
     dataset.varNamesCol,
     obsIndices,
@@ -93,9 +95,9 @@ export function Heatmap() {
   }, [fetchedData, hasSelections, isPending, serverError, updateColorscale]);
 
   useEffect(() => {
-    colorscale.current = dataset.controls.colorScale;
+    colorscale.current = settings.controls.colorScale;
     updateColorscale(colorscale.current);
-  }, [dataset.controls.colorScale, updateColorscale]);
+  }, [settings.controls.colorScale, updateColorscale]);
 
   if (!serverError) {
     if (hasSelections) {

--- a/src/lib/components/heatmap/HeatmapControls.js
+++ b/src/lib/components/heatmap/HeatmapControls.js
@@ -4,16 +4,19 @@ import _ from "lodash";
 import { Dropdown } from "react-bootstrap";
 
 import { COLORSCALES } from "../../constants/colorscales";
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 
 export function HeatmapControls() {
-  const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
 
   const colormapList = _.keys(COLORSCALES).map((key) => (
     <Dropdown.Item
       key={key}
-      active={dataset.controls.colorScale === key}
+      active={settings.controls.colorScale === key}
       onClick={() => {
         dispatch({
           type: "set.controls.colorScale",
@@ -28,7 +31,7 @@ export function HeatmapControls() {
   return (
     <Dropdown>
       <Dropdown.Toggle id="dropdownColorscale" variant="light">
-        {dataset.controls.colorScale}
+        {settings.controls.colorScale}
       </Dropdown.Toggle>
       <Dropdown.Menu>{colormapList}</Dropdown.Menu>
     </Dropdown>

--- a/src/lib/components/matrixplot/Matrixplot.js
+++ b/src/lib/components/matrixplot/Matrixplot.js
@@ -6,36 +6,38 @@ import Plot from "react-plotly.js";
 
 import { useDataset } from "../../context/DatasetContext";
 import { useFilteredData } from "../../context/FilterContext";
+import { useSettings } from "../../context/SettingsContext";
 import { LoadingSpinner } from "../../utils/LoadingIndicators";
 import { useDebouncedFetch } from "../../utils/requests";
 
 export function Matrixplot() {
   const ENDPOINT = "matrixplot";
   const dataset = useDataset();
+  const settings = useSettings();
   const { obsIndices, isSliced } = useFilteredData();
-  const colorscale = useRef(dataset.controls.colorScale);
+  const colorscale = useRef(settings.controls.colorScale);
   const [data, setData] = useState([]);
   const [layout, setLayout] = useState({});
   const [hasSelections, setHasSelections] = useState(false);
   const [params, setParams] = useState({
     url: dataset.url,
-    obsCol: dataset.selectedObs,
-    obsValues: !dataset.selectedObs?.omit.length
+    obsCol: settings.selectedObs,
+    obsValues: !settings.selectedObs?.omit.length
       ? null
       : _.difference(
-          _.values(dataset.selectedObs?.codes),
-          dataset.selectedObs?.omit
-        ).map((c) => dataset.selectedObs?.codesMap[c]),
-    varKeys: dataset.selectedMultiVar.map((i) =>
+          _.values(settings.selectedObs?.codes),
+          settings.selectedObs?.omit
+        ).map((c) => settings.selectedObs?.codesMap[c]),
+    varKeys: settings.selectedMultiVar.map((i) =>
       i.isSet ? { name: i.name, indices: i.vars.map((v) => v.index) } : i.index
     ),
     obsIndices: isSliced ? [...(obsIndices || [])] : null,
-    standardScale: dataset.controls.standardScale,
+    standardScale: settings.controls.standardScale,
     varNamesCol: dataset.varNamesCol,
   });
 
   useEffect(() => {
-    if (dataset.selectedObs && dataset.selectedMultiVar.length) {
+    if (settings.selectedObs && settings.selectedMultiVar.length) {
       setHasSelections(true);
     } else {
       setHasSelections(false);
@@ -44,27 +46,27 @@ export function Matrixplot() {
       return {
         ...p,
         url: dataset.url,
-        obsCol: dataset.selectedObs,
-        obsValues: !dataset.selectedObs?.omit.length
+        obsCol: settings.selectedObs,
+        obsValues: !settings.selectedObs?.omit.length
           ? null
           : _.difference(
-              _.values(dataset.selectedObs?.codes),
-              dataset.selectedObs?.omit
-            ).map((c) => dataset.selectedObs?.codesMap[c]),
-        varKeys: dataset.selectedMultiVar.map((i) =>
+              _.values(settings.selectedObs?.codes),
+              settings.selectedObs?.omit
+            ).map((c) => settings.selectedObs?.codesMap[c]),
+        varKeys: settings.selectedMultiVar.map((i) =>
           i.isSet
             ? { name: i.name, indices: i.vars.map((v) => v.index) }
             : i.index
         ),
         obsIndices: isSliced ? [...(obsIndices || [])] : null,
-        standardScale: dataset.controls.standardScale,
+        standardScale: settings.controls.standardScale,
         varNamesCol: dataset.varNamesCol,
       };
     });
   }, [
-    dataset.controls.standardScale,
-    dataset.selectedMultiVar,
-    dataset.selectedObs,
+    settings.controls.standardScale,
+    settings.selectedMultiVar,
+    settings.selectedObs,
     dataset.url,
     dataset.varNamesCol,
     obsIndices,
@@ -96,9 +98,9 @@ export function Matrixplot() {
   }, [fetchedData, hasSelections, isPending, serverError, updateColorscale]);
 
   useEffect(() => {
-    colorscale.current = dataset.controls.colorScale;
+    colorscale.current = settings.controls.colorScale;
     updateColorscale(colorscale.current);
-  }, [dataset.controls.colorScale, updateColorscale]);
+  }, [settings.controls.colorScale, updateColorscale]);
 
   if (!serverError) {
     if (hasSelections) {

--- a/src/lib/components/matrixplot/MatrixplotControls.js
+++ b/src/lib/components/matrixplot/MatrixplotControls.js
@@ -10,16 +10,19 @@ import {
 
 import { COLORSCALES } from "../../constants/colorscales";
 import { MATRIXPLOT_SCALES } from "../../constants/constants";
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 
 export function MatrixplotControls() {
-  const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
 
   const colorScaleList = _.keys(COLORSCALES).map((key) => (
     <Dropdown.Item
       key={key}
-      active={dataset.controls.colorScale === key}
+      active={settings.controls.colorScale === key}
       onClick={() => {
         dispatch({
           type: "set.controls.colorScale",
@@ -34,7 +37,7 @@ export function MatrixplotControls() {
   const standardScaleList = _.values(MATRIXPLOT_SCALES).map((scale) => (
     <Dropdown.Item
       key={scale.value}
-      active={dataset.controls.scale.matrixplot.name === scale.name}
+      active={settings.controls.scale.matrixplot.name === scale.name}
       onClick={() => {
         dispatch({
           type: "set.controls.scale",
@@ -52,7 +55,7 @@ export function MatrixplotControls() {
       <ButtonGroup>
         <Dropdown>
           <Dropdown.Toggle id="dropdownColorscale" variant="light">
-            {dataset.controls.colorScale}
+            {settings.controls.colorScale}
           </Dropdown.Toggle>
           <Dropdown.Menu>{colorScaleList}</Dropdown.Menu>
         </Dropdown>
@@ -62,7 +65,7 @@ export function MatrixplotControls() {
           <InputGroup.Text>Standard scale</InputGroup.Text>
           <Dropdown>
             <Dropdown.Toggle id="dropdownStandardScale" variant="light">
-              {dataset.controls.scale.matrixplot.name}
+              {settings.controls.scale.matrixplot.name}
             </Dropdown.Toggle>
             <Dropdown.Menu>{standardScaleList}</Dropdown.Menu>
           </Dropdown>

--- a/src/lib/components/obs-list/ObsList.js
+++ b/src/lib/components/obs-list/ObsList.js
@@ -20,7 +20,11 @@ import {
   DEFAULT_OBS_GROUP,
   OBS_TYPES,
 } from "../../constants/constants";
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import { useDataset } from "../../context/DatasetContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 import { LoadingSpinner } from "../../utils/LoadingIndicators";
 import { useFetch } from "../../utils/requests";
 
@@ -51,10 +55,11 @@ const ObsAccordionToggle = ({ children, eventKey, handleAccordionToggle }) => {
 export function ObsColsList({ showColor = true, enableObsGroups = true }) {
   const ENDPOINT = "obs/cols";
   const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
   const [enableGroups, setEnableGroups] = useState(enableObsGroups);
   const [obsCols, setObsCols] = useState(null);
-  const [active, setActive] = useState([...[dataset.selectedObs?.name]]);
+  const [active, setActive] = useState([...[settings.selectedObs?.name]]);
   const [params, setParams] = useState({ url: dataset.url });
   const obsGroups = useMemo(
     () => ({
@@ -111,12 +116,12 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
 
   useEffect(() => {
     if (obsCols) {
-      if (!obsCols[dataset.selectedObs?.name]) {
+      if (!obsCols[settings.selectedObs?.name]) {
         setActive([]);
         dispatch({ type: "select.obs", obs: null });
       }
     }
-  }, [dataset.selectedObs, dispatch, obsCols]);
+  }, [settings.selectedObs, dispatch, obsCols]);
 
   const handleAccordionToggle = (itemName, isCurrentEventKey) => {
     if (isCurrentEventKey) {
@@ -133,13 +138,13 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
     setObsCols((o) => {
       return { ...o, [item.name]: { ...item, omit: omit } };
     });
-    if (dataset.selectedObs?.name === item.name) {
+    if (settings.selectedObs?.name === item.name) {
       dispatch({ type: "select.obs", obs: { ...item, omit: omit } });
     }
   };
 
   const toggleLabel = (item) => {
-    const inLabelObs = _.some(dataset.labelObs, (i) => i.name === item.name);
+    const inLabelObs = _.some(settings.labelObs, (i) => i.name === item.name);
     if (inLabelObs) {
       dispatch({ type: "remove.label.obs", obsName: item.name });
     } else {
@@ -169,7 +174,7 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
     setObsCols((o) => {
       return { ...o, [item.name]: { ...item, omit: omit } };
     });
-    if (dataset.selectedObs?.name === item.name) {
+    if (settings.selectedObs?.name === item.name) {
       dispatch({ type: "select.obs", obs: { ...item, omit: omit } });
     }
   };
@@ -181,12 +186,12 @@ export function ObsColsList({ showColor = true, enableObsGroups = true }) {
     if (item.type === OBS_TYPES.DISCRETE) {
       return null;
     }
-    const inLabelObs = _.some(dataset.labelObs, (i) => i.name === item.name);
+    const inLabelObs = _.some(settings.labelObs, (i) => i.name === item.name);
     const inSliceObs =
-      dataset.sliceBy.obs && dataset.selectedObs?.name === item.name;
+      settings.sliceBy.obs && settings.selectedObs?.name === item.name;
     const isColorEncoding =
-      dataset.colorEncoding === COLOR_ENCODINGS.OBS &&
-      dataset.selectedObs?.name === item.name;
+      settings.colorEncoding === COLOR_ENCODINGS.OBS &&
+      settings.selectedObs?.name === item.name;
     return (
       <div className="accordion-item" key={item.name}>
         <ObsAccordionToggle

--- a/src/lib/components/obsm-list/ObsmList.js
+++ b/src/lib/components/obsm-list/ObsmList.js
@@ -9,14 +9,19 @@ import {
   Tooltip,
 } from "react-bootstrap";
 
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import { useDataset } from "../../context/DatasetContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 import { useFetch } from "../../utils/requests";
 import { ObsmKeysListBtn } from "../../utils/Skeleton";
 
 export function ObsmKeysList() {
   const ENDPOINT = "obsm/keys";
   const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
   const [obsmKeysList, setObsmKeysList] = useState([]);
   const [active, setActive] = useState(null);
   const [params, setParams] = useState({
@@ -43,10 +48,10 @@ export function ObsmKeysList() {
   }, [fetchedData, isPending, serverError]);
 
   useEffect(() => {
-    if (dataset.selectedObsm) {
-      setActive(dataset.selectedObsm);
+    if (settings.selectedObsm) {
+      setActive(settings.selectedObsm);
     }
-  }, [dataset.selectedObsm]);
+  }, [settings.selectedObsm]);
 
   const obsmList = obsmKeysList.map((item) => {
     return (
@@ -73,8 +78,8 @@ export function ObsmKeysList() {
     return (
       <DropdownButton
         as={ButtonGroup}
-        title={dataset.selectedObsm || "Select an embedding"}
-        variant={dataset.selectedObsm ? "primary" : "warning"}
+        title={settings.selectedObsm || "Select an embedding"}
+        variant={settings.selectedObsm ? "primary" : "warning"}
         id="bg-nested-dropdown"
         size="sm"
       >

--- a/src/lib/components/pseudospatial/PseudospatialToolbar.js
+++ b/src/lib/components/pseudospatial/PseudospatialToolbar.js
@@ -1,23 +1,26 @@
 import React, { useEffect, useState } from "react";
 
-import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import _ from "lodash";
 import { ButtonGroup, Dropdown, Form } from "react-bootstrap";
+
 import {
   PSEUDOSPATIAL_CATEGORICAL_MODES as MODES,
   PSEUDOSPATIAL_PLOT_TYPES as PLOT_TYPES,
 } from "../../constants/constants";
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import { useDataset } from "../../context/DatasetContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 import { useFetch } from "../../utils/requests";
 
 function CategoricalMode() {
-  const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
   const modeList = _.map(MODES, (m, key) => (
     <Dropdown.Item
       key={key}
-      active={dataset.pseudospatial.categoricalMode === m}
+      active={settings.pseudospatial.categoricalMode === m}
       onClick={() => {
         dispatch({
           type: "set.pseudospatial.categoricalMode",
@@ -29,7 +32,7 @@ function CategoricalMode() {
     </Dropdown.Item>
   ));
 
-  const mode = _.find(MODES, { value: dataset.pseudospatial.categoricalMode });
+  const mode = _.find(MODES, { value: settings.pseudospatial.categoricalMode });
 
   return (
     <Dropdown>
@@ -44,7 +47,8 @@ function CategoricalMode() {
 function MaskSet() {
   const ENDPOINT = "masks";
   const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
   const [maskSets, setMaskSets] = useState(null);
 
   const [params, setParams] = useState({ url: dataset.url });
@@ -68,7 +72,7 @@ function MaskSet() {
   const maskSetList = _.map(maskSets, (ms, key) => (
     <Dropdown.Item
       key={key}
-      active={dataset.pseudospatial.maskSet === key}
+      active={settings.pseudospatial.maskSet === key}
       onClick={() => {
         dispatch({ type: "set.pseudospatial.maskSet", maskSet: key });
       }}
@@ -79,15 +83,16 @@ function MaskSet() {
 
   const handleMaskChange = (mask) => {
     let newMasks =
-      dataset.pseudospatial.maskValues ||
-      maskSets?.[dataset.pseudospatial?.maskSet];
+      settings.pseudospatial.maskValues ||
+      maskSets?.[settings.pseudospatial?.maskSet];
 
     newMasks = newMasks.includes(mask)
       ? newMasks.filter((m) => m !== mask)
       : [...newMasks, mask];
 
     if (
-      !_.difference(maskSets?.[dataset.pseudospatial?.maskSet], newMasks).length
+      !_.difference(maskSets?.[settings.pseudospatial?.maskSet], newMasks)
+        .length
     ) {
       newMasks = null;
     }
@@ -97,9 +102,9 @@ function MaskSet() {
 
   const toggleMasks = () => {
     if (
-      !dataset.pseudospatial.maskValues ||
-      dataset.pseudospatial.maskValues?.length ===
-        maskSets?.[dataset.pseudospatial?.maskSet]?.length
+      !settings.pseudospatial.maskValues ||
+      settings.pseudospatial.maskValues?.length ===
+        maskSets?.[settings.pseudospatial?.maskSet]?.length
     ) {
       dispatch({ type: "set.pseudospatial.maskValues", maskValues: [] });
     } else {
@@ -108,15 +113,15 @@ function MaskSet() {
   };
 
   const masksList = _.map(
-    maskSets?.[dataset.pseudospatial?.maskSet],
+    maskSets?.[settings.pseudospatial?.maskSet],
     (mask) => (
       <Dropdown.ItemText key={mask}>
         <Form.Check
           type="checkbox"
           label={mask}
           checked={
-            !dataset.pseudospatial.maskValues ||
-            dataset.pseudospatial.maskValues.includes(mask)
+            !settings.pseudospatial.maskValues ||
+            settings.pseudospatial.maskValues.includes(mask)
           }
           onChange={() => handleMaskChange(mask)}
         />
@@ -124,20 +129,20 @@ function MaskSet() {
     )
   );
 
-  const nMasks = dataset.pseudospatial.maskValues
-    ? dataset.pseudospatial.maskValues?.length
-    : maskSets?.[dataset.pseudospatial?.maskSet]?.length || "No";
+  const nMasks = settings.pseudospatial.maskValues
+    ? settings.pseudospatial.maskValues?.length
+    : maskSets?.[settings.pseudospatial?.maskSet]?.length || "No";
 
   const toggleAllChecked =
-    !dataset.pseudospatial.maskValues ||
-    dataset.pseudospatial.maskValues?.length ===
-      maskSets?.[dataset.pseudospatial?.maskSet]?.length;
+    !settings.pseudospatial.maskValues ||
+    settings.pseudospatial.maskValues?.length ===
+      maskSets?.[settings.pseudospatial?.maskSet]?.length;
 
   return (
     <>
       <Dropdown>
         <Dropdown.Toggle variant="light">
-          {_.capitalize(dataset.pseudospatial.maskSet || "Select a mask set")}
+          {_.capitalize(settings.pseudospatial.maskSet || "Select a mask set")}
         </Dropdown.Toggle>
         <Dropdown.Menu>
           <Dropdown.Header>Mask set</Dropdown.Header>

--- a/src/lib/components/scatterplot/Scatterplot.js
+++ b/src/lib/components/scatterplot/Scatterplot.js
@@ -420,9 +420,9 @@ export function Scatterplot({
             <Toolbox
               mode={
                 settings.colorEncoding === COLOR_ENCODINGS.VAR
-                  ? settings.selectedVar.name
+                  ? settings.selectedVar?.name
                   : settings.colorEncoding === COLOR_ENCODINGS.OBS
-                    ? settings.selectedObs.name
+                    ? settings.selectedObs?.name
                     : null
               }
               obsLength={parseInt(obsmData.data?.length)}

--- a/src/lib/components/scatterplot/Scatterplot.js
+++ b/src/lib/components/scatterplot/Scatterplot.js
@@ -24,8 +24,11 @@ import {
   SELECTED_POLYGON_FILLCOLOR,
   UNSELECTED_POLYGON_FILLCOLOR,
 } from "../../constants/constants";
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
 import { useFilteredData } from "../../context/FilterContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 import { useZarrData } from "../../context/ZarrDataContext";
 import { rgbToHex, useColor } from "../../helpers/color-helper";
 import { MapHelper } from "../../helpers/map-helper";
@@ -51,9 +54,9 @@ export function Scatterplot({
   setShowVars,
   isFullscreen = false,
 }) {
-  const dataset = useDataset();
+  const settings = useSettings();
   const { obsIndices, valueMin, valueMax, slicedLength } = useFilteredData();
-  const dispatch = useDatasetDispatch();
+  const dispatch = useSettingsDispatch();
   const { getColor } = useColor();
   const deckRef = useRef(null);
   const [viewState, setViewState] = useState(INITIAL_VIEW_STATE);
@@ -69,7 +72,7 @@ export function Scatterplot({
   const [mode, setMode] = useState(() => ViewMode);
   const [features, setFeatures] = useState({
     type: "FeatureCollection",
-    features: dataset.polygons[dataset.selectedObsm] || [],
+    features: settings.polygons[settings.selectedObsm] || [],
   });
   const [selectedFeatureIndexes, setSelectedFeatureIndexes] = useState([]);
 
@@ -98,7 +101,7 @@ export function Scatterplot({
       });
     }
   }, [
-    dataset.selectedObsm,
+    settings.selectedObsm,
     obsmData.data,
     obsmData.isPending,
     obsmData.serverError,
@@ -117,7 +120,7 @@ export function Scatterplot({
   }, [data.positions]);
 
   useEffect(() => {
-    if (dataset.colorEncoding === COLOR_ENCODINGS.VAR) {
+    if (settings.colorEncoding === COLOR_ENCODINGS.VAR) {
       setIsRendering(true);
       if (!xData.isPending && !xData.serverError) {
         // @TODO: add condition to check obs slicing
@@ -131,7 +134,7 @@ export function Scatterplot({
       }
     }
   }, [
-    dataset.colorEncoding,
+    settings.colorEncoding,
     xData.data,
     xData.isPending,
     xData.serverError,
@@ -139,7 +142,7 @@ export function Scatterplot({
   ]);
 
   useEffect(() => {
-    if (dataset.colorEncoding === COLOR_ENCODINGS.OBS) {
+    if (settings.colorEncoding === COLOR_ENCODINGS.OBS) {
       setIsRendering(true);
       if (!obsData.isPending && !obsData.serverError) {
         setData((d) => {
@@ -151,8 +154,8 @@ export function Scatterplot({
         });
       }
     } else if (
-      dataset.colorEncoding === COLOR_ENCODINGS.VAR &&
-      dataset.sliceBy.obs
+      settings.colorEncoding === COLOR_ENCODINGS.VAR &&
+      settings.sliceBy.obs
     ) {
       if (!obsData.isPending && !obsData.serverError) {
         setData((d) => {
@@ -165,23 +168,23 @@ export function Scatterplot({
       }
     }
   }, [
-    dataset.colorEncoding,
+    settings.colorEncoding,
     obsData.data,
     obsData.isPending,
     obsData.serverError,
-    dataset.sliceBy.obs,
+    settings.sliceBy.obs,
   ]);
 
   const isCategorical = useMemo(() => {
-    if (dataset.colorEncoding === COLOR_ENCODINGS.OBS) {
+    if (settings.colorEncoding === COLOR_ENCODINGS.OBS) {
       return (
-        dataset.selectedObs?.type === OBS_TYPES.CATEGORICAL ||
-        dataset.selectedObs?.type === OBS_TYPES.BOOLEAN
+        settings.selectedObs?.type === OBS_TYPES.CATEGORICAL ||
+        settings.selectedObs?.type === OBS_TYPES.BOOLEAN
       );
     } else {
       return false;
     }
-  }, [dataset.colorEncoding, dataset.selectedObs?.type]);
+  }, [settings.colorEncoding, settings.selectedObs?.type]);
 
   useEffect(() => {
     dispatch({
@@ -191,8 +194,8 @@ export function Scatterplot({
   }, [dispatch, valueMax, valueMin]);
 
   const { min, max } = {
-    min: dataset.controls.range[0] * (valueMax - valueMin) + valueMin,
-    max: dataset.controls.range[1] * (valueMax - valueMin) + valueMin,
+    min: settings.controls.range[0] * (valueMax - valueMin) + valueMin,
+    max: settings.controls.range[1] * (valueMax - valueMin) + valueMin,
   };
 
   const getFillColor = useCallback(
@@ -289,10 +292,10 @@ export function Scatterplot({
   useEffect(() => {
     dispatch({
       type: "set.polygons",
-      obsm: dataset.selectedObsm,
+      obsm: settings.selectedObsm,
       polygons: features?.features || [],
     });
-  }, [dataset.selectedObsm, dispatch, features.features]);
+  }, [settings.selectedObsm, dispatch, features.features]);
 
   function onLayerClick(info) {
     if (mode !== ViewMode) {
@@ -322,21 +325,24 @@ export function Scatterplot({
     const text = [];
 
     if (
-      dataset.colorEncoding === COLOR_ENCODINGS.OBS &&
-      dataset.selectedObs &&
-      !_.some(dataset.labelObs, { name: dataset.selectedObs.name })
+      settings.colorEncoding === COLOR_ENCODINGS.OBS &&
+      settings.selectedObs &&
+      !_.some(settings.labelObs, { name: settings.selectedObs.name })
     ) {
-      text.push(getLabel(dataset.selectedObs, obsData.data?.[index]));
+      text.push(getLabel(settings.selectedObs, obsData.data?.[index]));
     }
 
-    if (dataset.colorEncoding === COLOR_ENCODINGS.VAR && dataset.selectedVar) {
-      text.push(getLabel(dataset.selectedVar, xData.data?.[index], true));
+    if (
+      settings.colorEncoding === COLOR_ENCODINGS.VAR &&
+      settings.selectedVar
+    ) {
+      text.push(getLabel(settings.selectedVar, xData.data?.[index], true));
     }
 
-    if (dataset.labelObs.length) {
+    if (settings.labelObs.length) {
       text.push(
         ..._.map(labelObsData.data, (v, k) => {
-          const labelObs = _.find(dataset.labelObs, (o) => o.name === k);
+          const labelObs = _.find(settings.labelObs, (o) => o.name === k);
           return getLabel(labelObs, v[index]);
         })
       );
@@ -362,12 +368,12 @@ export function Scatterplot({
     !obsmData.isPending;
 
   const error =
-    (dataset.selectedObsm && obsmData.serverError?.length) ||
-    (dataset.colorEncoding === COLOR_ENCODINGS.VAR &&
+    (settings.selectedObsm && obsmData.serverError?.length) ||
+    (settings.colorEncoding === COLOR_ENCODINGS.VAR &&
       xData.serverError?.length) ||
-    (dataset.colorEncoding === COLOR_ENCODINGS.OBS &&
+    (settings.colorEncoding === COLOR_ENCODINGS.OBS &&
       obsData.serverError?.length) ||
-    (dataset.labelObs.lengh && labelObsData.serverError?.length);
+    (settings.labelObs.lengh && labelObsData.serverError?.length);
 
   return (
     <div className="cherita-container-scatterplot">
@@ -413,10 +419,10 @@ export function Scatterplot({
             )}
             <Toolbox
               mode={
-                dataset.colorEncoding === COLOR_ENCODINGS.VAR
-                  ? dataset.selectedVar.name
-                  : dataset.colorEncoding === COLOR_ENCODINGS.OBS
-                    ? dataset.selectedObs.name
+                settings.colorEncoding === COLOR_ENCODINGS.VAR
+                  ? settings.selectedVar.name
+                  : settings.colorEncoding === COLOR_ENCODINGS.OBS
+                    ? settings.selectedObs.name
                     : null
               }
               obsLength={parseInt(obsmData.data?.length)}

--- a/src/lib/components/scatterplot/ScatterplotControls.js
+++ b/src/lib/components/scatterplot/ScatterplotControls.js
@@ -6,24 +6,27 @@ import { Dropdown } from "react-bootstrap";
 
 import { COLORSCALES } from "../../constants/colorscales";
 import { COLOR_ENCODINGS, OBS_TYPES } from "../../constants/constants";
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 
 export const ScatterplotControls = () => {
-  const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
   const [sliderValue, setSliderValue] = React.useState(
-    dataset.controls.range || [0, 1]
+    settings.controls.range || [0, 1]
   );
 
   const isCategorical =
-    dataset.colorEncoding === COLOR_ENCODINGS.OBS
-      ? dataset.selectedObs?.type === OBS_TYPES.CATEGORICAL
+    settings.colorEncoding === COLOR_ENCODINGS.OBS
+      ? settings.selectedObs?.type === OBS_TYPES.CATEGORICAL
       : false;
 
   const colormapList = _.keys(COLORSCALES).map((key) => (
     <Dropdown.Item
       key={key}
-      active={dataset.controls.colorScale === key}
+      active={settings.controls.colorScale === key}
       onClick={() => {
         dispatch({
           type: "set.controls.colorScale",
@@ -38,8 +41,8 @@ export const ScatterplotControls = () => {
   const valueLabelFormat = (value) => {
     return (
       value *
-        (dataset.controls.valueRange[1] - dataset.controls.valueRange[0]) +
-      dataset.controls.valueRange[0]
+        (settings.controls.valueRange[1] - settings.controls.valueRange[0]) +
+      settings.controls.valueRange[0]
     ).toFixed(2);
   };
 
@@ -61,8 +64,8 @@ export const ScatterplotControls = () => {
   };
 
   useEffect(() => {
-    setSliderValue(dataset.controls.range);
-  }, [dataset.controls.range]);
+    setSliderValue(settings.controls.range);
+  }, [settings.controls.range]);
 
   const rangeSlider = (
     <Box className="w-100">
@@ -90,7 +93,7 @@ export const ScatterplotControls = () => {
     <div>
       <Dropdown>
         <Dropdown.Toggle id="dropdownColorscale" variant="light">
-          {dataset.controls.colorScale}
+          {settings.controls.colorScale}
         </Dropdown.Toggle>
         <Dropdown.Menu>{colormapList}</Dropdown.Menu>
       </Dropdown>

--- a/src/lib/components/scatterplot/SpatialControls.js
+++ b/src/lib/components/scatterplot/SpatialControls.js
@@ -28,9 +28,13 @@ import Button from "react-bootstrap/Button";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import Dropdown from "react-bootstrap/Dropdown";
 
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import { useDataset } from "../../context/DatasetContext";
 import { OffcanvasControls } from "../offcanvas";
 import { ScatterplotControls } from "./ScatterplotControls";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 
 export function SpatialControls({
   mode,
@@ -45,8 +49,8 @@ export function SpatialControls({
   setShowVars,
   isFullscreen,
 }) {
-  const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
   const [showControls, setShowControls] = useState(false);
 
   const handleCloseControls = () => setShowControls(false);
@@ -89,7 +93,7 @@ export function SpatialControls({
   const polygonControls = (
     <>
       <Button
-        active={dataset.sliceBy.polygons}
+        active={settings.sliceBy.polygons}
         title="Filter data with polygons"
         onClick={() => {
           setMode(() => ViewMode);

--- a/src/lib/components/search-bar/SearchBar.js
+++ b/src/lib/components/search-bar/SearchBar.js
@@ -30,8 +30,8 @@ function onVarSelect(dispatch, item) {
 
 function addVarSet(dispatch, { name, vars }) {
   dispatch({
-    type: "add.varSet",
-    varSet: {
+    type: "add.var",
+    var: {
       name: name,
       vars: vars,
       isSet: true,

--- a/src/lib/components/search-bar/SearchInfo.js
+++ b/src/lib/components/search-bar/SearchInfo.js
@@ -6,7 +6,11 @@ import _ from "lodash";
 import { Button, ListGroup } from "react-bootstrap";
 
 import { VAR_SORT } from "../../constants/constants";
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import { useDataset } from "../../context/DatasetContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 import { useFetch } from "../../utils/requests";
 import { VarDiseaseInfo } from "../var-list/VarItem";
 
@@ -87,7 +91,8 @@ const sortMeans = (i, means) => {
 export function DiseaseInfo({ disease, handleSelect, addVarSet }) {
   const ENDPOINT = "disease/genes";
   const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
   const [diseaseVars, setDiseaseVars] = useState([]);
   const [sortedDiseaseVars, setSortedDiseaseVars] = useState([]);
   const [params, setParams] = useState({
@@ -116,11 +121,11 @@ export function DiseaseInfo({ disease, handleSelect, addVarSet }) {
 
   const varMeans = useVarMean(
     diseaseVars,
-    !!diseaseVars?.length && dataset.varSort.disease.sort === VAR_SORT.MATRIX
+    !!diseaseVars?.length && settings.varSort.disease.sort === VAR_SORT.MATRIX
   );
 
   useEffect(() => {
-    if (dataset.varSort.disease.sort === VAR_SORT.MATRIX) {
+    if (settings.varSort.disease.sort === VAR_SORT.MATRIX) {
       if (!varMeans.isPending && !varMeans.serverError) {
         setSortedDiseaseVars(
           _.orderBy(
@@ -128,20 +133,20 @@ export function DiseaseInfo({ disease, handleSelect, addVarSet }) {
             (o) => {
               return sortMeans(o, varMeans.fetchedData);
             },
-            dataset.varSort.disease.sortOrder
+            settings.varSort.disease.sortOrder
           )
         );
       }
-    } else if (dataset.varSort.disease.sort === VAR_SORT.NAME) {
+    } else if (settings.varSort.disease.sort === VAR_SORT.NAME) {
       setSortedDiseaseVars(
-        _.orderBy(diseaseVars, "name", dataset.varSort.disease.sortOrder)
+        _.orderBy(diseaseVars, "name", settings.varSort.disease.sortOrder)
       );
     } else {
       setSortedDiseaseVars(diseaseVars);
     }
   }, [
-    dataset.varSort.disease.sort,
-    dataset.varSort.disease.sortOrder,
+    settings.varSort.disease.sort,
+    settings.varSort.disease.sortOrder,
     diseaseVars,
     varMeans.fetchedData,
     varMeans.isPending,
@@ -173,7 +178,7 @@ export function DiseaseInfo({ disease, handleSelect, addVarSet }) {
 
   const isPending =
     diseaseData.isPending ||
-    (varMeans.isPending && dataset.varSort.disease.sort === VAR_SORT.MATRIX);
+    (varMeans.isPending && settings.varSort.disease.sort === VAR_SORT.MATRIX);
 
   return (
     <div>

--- a/src/lib/components/search-bar/SearchInfo.js
+++ b/src/lib/components/search-bar/SearchInfo.js
@@ -165,7 +165,11 @@ export function DiseaseInfo({ disease, handleSelect, addVarSet }) {
               variant="outline-secondary"
               title="Add to list"
               onClick={() => {
-                handleSelect(dispatch, v);
+                handleSelect(dispatch, {
+                  name: v.name,
+                  index: v.index,
+                  matrix_index: v.matrix_index,
+                });
               }}
             >
               <FontAwesomeIcon icon={faPlus} />

--- a/src/lib/components/search-bar/SearchResults.js
+++ b/src/lib/components/search-bar/SearchResults.js
@@ -121,8 +121,6 @@ export function DiseasesSearchResults({
   setResultsLength,
 }) {
   const [suggestions, setSuggestions] = useState([]);
-  const dispatch = useSettingsDispatch();
-
   const {
     setParams,
     data: { fetchedData = [], isPending, serverError },
@@ -163,11 +161,6 @@ export function DiseasesSearchResults({
           key={item.name}
           onClick={() => {
             setSelectedResult(item);
-            dispatch({
-              type: "select.disease",
-              id: item.disease_id,
-              name: item.disease_name,
-            });
           }}
           active={selectedResult?.id === item.id}
         >

--- a/src/lib/components/search-bar/SearchResults.js
+++ b/src/lib/components/search-bar/SearchResults.js
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import _ from "lodash";
 import { Button, ListGroup } from "react-bootstrap";
 
-import { useDatasetDispatch } from "../../context/DatasetContext";
+import { useSettingsDispatch } from "../../context/SettingsContext";
 import { useDiseaseSearch, useVarSearch } from "../../utils/search";
 import { VirtualizedList } from "../../utils/VirtualizedList";
 
@@ -17,7 +17,7 @@ export function VarSearchResults({
   setResultsLength,
 }) {
   const [suggestions, setSuggestions] = useState([]);
-  const dispatch = useDatasetDispatch();
+  const dispatch = useSettingsDispatch();
 
   const {
     setParams,
@@ -121,7 +121,7 @@ export function DiseasesSearchResults({
   setResultsLength,
 }) {
   const [suggestions, setSuggestions] = useState([]);
-  const dispatch = useDatasetDispatch();
+  const dispatch = useSettingsDispatch();
 
   const {
     setParams,

--- a/src/lib/components/var-list/VarItem.js
+++ b/src/lib/components/var-list/VarItem.js
@@ -56,20 +56,9 @@ function VarHistogram({ item }) {
 }
 
 function VarDiseaseInfoItem(item) {
-  const dispatch = useSettingsDispatch();
   return (
     <ListGroup.Item key={item.disease_id} className="feature-disease-info">
-      <button
-        type="button"
-        className="btn btn-link disease-link"
-        onClick={() => {
-          dispatch({
-            type: "select.disease",
-            id: item.disease_id,
-            name: item.disease_name,
-          });
-        }}
-      >
+      <button type="button" className="btn btn-link disease-link">
         {item.disease_name}
       </button>
       <Table striped size="sm" responsive>
@@ -230,7 +219,6 @@ function MultipleSelectionItem({ item, isActive, toggleVar }) {
 export function VarItem({
   item,
   active,
-  setVarButtons,
   mode = SELECTION_MODES.SINGLE,
   isDiseaseGene = false,
 }) {
@@ -260,8 +248,9 @@ export function VarItem({
   };
 
   const removeVar = () => {
-    setVarButtons((b) => {
-      return b.filter((i) => i.name !== item.name);
+    dispatch({
+      type: "remove.var",
+      var: item,
     });
     if (mode === SELECTION_MODES.SINGLE) {
       if (active === item.matrix_index) {
@@ -280,14 +269,10 @@ export function VarItem({
   };
 
   const toggleVar = () => {
-    if (active.includes(item.matrix_index)) {
-      dispatch({
-        type: "deselect.multivar",
-        var: item,
-      });
-    } else {
-      selectVar(item);
-    }
+    dispatch({
+      type: "toggle.multivar",
+      var: item,
+    });
   };
 
   if (item && mode === SELECTION_MODES.SINGLE) {

--- a/src/lib/components/var-list/VarItem.js
+++ b/src/lib/components/var-list/VarItem.js
@@ -7,8 +7,12 @@ import _ from "lodash";
 import { Button, Collapse, ListGroup, Table } from "react-bootstrap";
 
 import { COLOR_ENCODINGS, SELECTION_MODES } from "../../constants/constants";
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import { useDataset } from "../../context/DatasetContext";
 import { useFilteredData } from "../../context/FilterContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 import { Histogram } from "../../utils/Histogram";
 import { useDebouncedFetch, useFetch } from "../../utils/requests";
 import { VirtualizedList } from "../../utils/VirtualizedList";
@@ -16,10 +20,11 @@ import { VirtualizedList } from "../../utils/VirtualizedList";
 function VarHistogram({ item }) {
   const ENDPOINT = "var/histograms";
   const dataset = useDataset();
+  const settings = useSettings();
   const { obsIndices } = useFilteredData();
   // @TODO: consider using Filter's isSliced; would trigger more re-renders/requests
   // const { obsIndices, isSliced } = useFilteredData();
-  const isSliced = dataset.sliceBy.obs || dataset.sliceBy.polygons;
+  const isSliced = settings.sliceBy.obs || settings.sliceBy.polygons;
   const [params, setParams] = useState({
     url: dataset.url,
     varKey: item.matrix_index,
@@ -51,7 +56,7 @@ function VarHistogram({ item }) {
 }
 
 function VarDiseaseInfoItem(item) {
-  const dispatch = useDatasetDispatch();
+  const dispatch = useSettingsDispatch();
   return (
     <ListGroup.Item key={item.disease_id} className="feature-disease-info">
       <button
@@ -229,8 +234,8 @@ export function VarItem({
   mode = SELECTION_MODES.SINGLE,
   isDiseaseGene = false,
 }) {
-  const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
 
   const selectVar = () => {
     if (mode === SELECTION_MODES.SINGLE) {
@@ -290,7 +295,7 @@ export function VarItem({
       <SingleSelectionItem
         item={item}
         isActive={
-          dataset.colorEncoding === COLOR_ENCODINGS.VAR &&
+          settings.colorEncoding === COLOR_ENCODINGS.VAR &&
           active === item.matrix_index
         }
         selectVar={selectVar}

--- a/src/lib/components/var-list/VarListToolbar.js
+++ b/src/lib/components/var-list/VarListToolbar.js
@@ -11,18 +11,21 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ToggleButton, ToggleButtonGroup } from "react-bootstrap";
 
 import { VAR_SORT, VAR_SORT_ORDER } from "../../constants/constants";
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 
 // @TODO: set option for "var" and "disease"
 export function VarListToolbar({ varType = "var" }) {
-  const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
-  const [sort, setSort] = useState(dataset.varSort.var.sort);
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
+  const [sort, setSort] = useState(settings.varSort.var.sort);
   const [nameSortOrder, setNameSortOrder] = useState(
-    dataset.varSort.var.sortOrder
+    settings.varSort.var.sortOrder
   );
   const [matrixSortOrder, setMatrixSortOrder] = useState(
-    dataset.varSort.var.sortOrder
+    settings.varSort.var.sortOrder
   );
 
   const handleSort = (sortValue, sortOrder, setSortOrder) => {

--- a/src/lib/components/var-list/VarSet.js
+++ b/src/lib/components/var-list/VarSet.js
@@ -20,7 +20,10 @@ import {
 
 import { SingleSelectionItem } from "./VarItem";
 import { COLOR_ENCODINGS, SELECTION_MODES } from "../../constants/constants";
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 import { SearchModal } from "../search-bar/SearchBar";
 
 // @TODO: add button to score genes and plot
@@ -182,8 +185,8 @@ function MultipleSelectionSet({ set, isActive, toggleSet }) {
 }
 
 export function VarSet({ set, active, mode = SELECTION_MODES.SINGLE }) {
-  const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
 
   const selectSet = () => {
     if (mode === SELECTION_MODES.SINGLE) {
@@ -248,7 +251,7 @@ export function VarSet({ set, active, mode = SELECTION_MODES.SINGLE }) {
       <SingleSelectionSet
         set={set}
         isActive={
-          dataset.colorEncoding === COLOR_ENCODINGS.VAR && active === set.name
+          settings.colorEncoding === COLOR_ENCODINGS.VAR && active === set.name
         }
         selectSet={selectSet}
         removeSet={removeSet}

--- a/src/lib/components/var-list/VarSet.js
+++ b/src/lib/components/var-list/VarSet.js
@@ -107,7 +107,6 @@ function SingleSelectionSet({
                 e.stopPropagation();
                 setShowModal(true);
               }}
-              disabled={!set.vars.length}
               title="Add to set"
             >
               <FontAwesomeIcon icon={faPlus} />
@@ -222,8 +221,8 @@ export function VarSet({ set, active, mode = SELECTION_MODES.SINGLE }) {
       }
     }
     dispatch({
-      type: "remove.varSet",
-      varSet: set,
+      type: "remove.var",
+      var: set,
     });
   };
 
@@ -236,14 +235,10 @@ export function VarSet({ set, active, mode = SELECTION_MODES.SINGLE }) {
   };
 
   const toggleSet = () => {
-    if (active.includes(set.name)) {
-      dispatch({
-        type: "deselect.multivar",
-        var: set,
-      });
-    } else {
-      selectSet();
-    }
+    dispatch({
+      type: "toggle.multivar",
+      var: set,
+    });
   };
 
   if (set && mode === SELECTION_MODES.SINGLE) {
@@ -263,7 +258,7 @@ export function VarSet({ set, active, mode = SELECTION_MODES.SINGLE }) {
       <MultipleSelectionSet
         set={set}
         isActive={_.includes(active, set.name)}
-        toggleSet={() => toggleSet(set)}
+        toggleSet={toggleSet}
       />
     );
   } else {

--- a/src/lib/components/violin/Violin.js
+++ b/src/lib/components/violin/Violin.js
@@ -9,12 +9,14 @@ import Plot from "react-plotly.js";
 import { VIOLIN_MODES } from "../../constants/constants";
 import { useDataset } from "../../context/DatasetContext";
 import { useFilteredData } from "../../context/FilterContext";
+import { useSettings } from "../../context/SettingsContext";
 import { LoadingSpinner } from "../../utils/LoadingIndicators";
 import { useDebouncedFetch } from "../../utils/requests";
 
 export function Violin({ mode = VIOLIN_MODES.MULTIKEY }) {
   const ENDPOINT = "violin";
   const dataset = useDataset();
+  const settings = useSettings();
   const { obsIndices, isSliced } = useFilteredData();
   const [data, setData] = useState([]);
   const [layout, setLayout] = useState({});
@@ -22,11 +24,11 @@ export function Violin({ mode = VIOLIN_MODES.MULTIKEY }) {
   const [params, setParams] = useState({
     url: dataset.url,
     mode: mode,
-    scale: dataset.controls.scale.violinplot.value,
+    scale: settings.controls.scale.violinplot.value,
     varNamesCol: dataset.varNamesCol,
     ...{
       [VIOLIN_MODES.MULTIKEY]: {
-        varKeys: dataset.selectedMultiVar.map((i) =>
+        varKeys: settings.selectedMultiVar.map((i) =>
           i.isSet
             ? { name: i.name, indices: i.vars.map((v) => v.index) }
             : i.index
@@ -34,19 +36,19 @@ export function Violin({ mode = VIOLIN_MODES.MULTIKEY }) {
         obsKeys: [], // @TODO: implement
       },
       [VIOLIN_MODES.GROUPBY]: {
-        varKey: dataset.selectedVar?.isSet
+        varKey: settings.selectedVar?.isSet
           ? {
-              name: dataset.selectedVar?.name,
-              indices: dataset.selectedVar?.vars.map((v) => v.index),
+              name: settings.selectedVar?.name,
+              indices: settings.selectedVar?.vars.map((v) => v.index),
             }
-          : dataset.selectedVar?.index,
-        obsCol: dataset.selectedObs,
-        obsValues: !dataset.selectedObs?.omit.length
+          : settings.selectedVar?.index,
+        obsCol: settings.selectedObs,
+        obsValues: !settings.selectedObs?.omit.length
           ? null
           : _.difference(
-              _.values(dataset.selectedObs?.codes),
-              dataset.selectedObs?.omit
-            ).map((c) => dataset.selectedObs?.codesMap[c]),
+              _.values(settings.selectedObs?.codes),
+              settings.selectedObs?.omit
+            ).map((c) => settings.selectedObs?.codesMap[c]),
         obsIndices: isSliced ? [...(obsIndices || [])] : null,
       },
     }[mode],
@@ -55,7 +57,7 @@ export function Violin({ mode = VIOLIN_MODES.MULTIKEY }) {
 
   useEffect(() => {
     if (mode === VIOLIN_MODES.MULTIKEY) {
-      if (dataset.selectedMultiVar.length) {
+      if (settings.selectedMultiVar.length) {
         setHasSelections(true);
       } else {
         setHasSelections(false);
@@ -65,17 +67,17 @@ export function Violin({ mode = VIOLIN_MODES.MULTIKEY }) {
           ...p,
           url: dataset.url,
           mode: mode,
-          varKeys: dataset.selectedMultiVar.map((i) =>
+          varKeys: settings.selectedMultiVar.map((i) =>
             i.isSet
               ? { name: i.name, indices: i.vars.map((v) => v.index) }
               : i.index
           ),
-          scale: dataset.controls.scale.violinplot.value,
+          scale: settings.controls.scale.violinplot.value,
           varNamesCol: dataset.varNamesCol,
         };
       });
     } else if (mode === VIOLIN_MODES.GROUPBY) {
-      if (dataset.selectedObs && dataset.selectedVar) {
+      if (settings.selectedObs && settings.selectedVar) {
         setHasSelections(true);
       } else {
         setHasSelections(false);
@@ -85,30 +87,30 @@ export function Violin({ mode = VIOLIN_MODES.MULTIKEY }) {
           ...p,
           url: dataset.url,
           mode: mode,
-          varKey: dataset.selectedVar?.isSet
+          varKey: settings.selectedVar?.isSet
             ? {
-                name: dataset.selectedVar?.name,
-                indices: dataset.selectedVar?.vars.map((v) => v.index),
+                name: settings.selectedVar?.name,
+                indices: settings.selectedVar?.vars.map((v) => v.index),
               }
-            : dataset.selectedVar?.index,
-          obsCol: dataset.selectedObs,
-          obsValues: !dataset.selectedObs?.omit.length
+            : settings.selectedVar?.index,
+          obsCol: settings.selectedObs,
+          obsValues: !settings.selectedObs?.omit.length
             ? null
             : _.difference(
-                _.values(dataset.selectedObs?.codes),
-                dataset.selectedObs?.omit
-              ).map((c) => dataset.selectedObs?.codesMap[c]),
+                _.values(settings.selectedObs?.codes),
+                settings.selectedObs?.omit
+              ).map((c) => settings.selectedObs?.codesMap[c]),
           obsIndices: isSliced ? [...(obsIndices || [])] : null,
-          scale: dataset.controls.scale.violinplot.value,
+          scale: settings.controls.scale.violinplot.value,
           varNamesCol: dataset.varNamesCol,
         };
       });
     }
   }, [
-    dataset.controls.scale.violinplot.value,
-    dataset.selectedMultiVar,
-    dataset.selectedObs,
-    dataset.selectedVar,
+    settings.controls.scale.violinplot.value,
+    settings.selectedMultiVar,
+    settings.selectedObs,
+    settings.selectedVar,
     dataset.url,
     dataset.varNamesCol,
     obsIndices,

--- a/src/lib/components/violin/ViolinControls.js
+++ b/src/lib/components/violin/ViolinControls.js
@@ -9,16 +9,19 @@ import {
 } from "react-bootstrap";
 
 import { VIOLINPLOT_SCALES } from "../../constants/constants";
-import { useDataset, useDatasetDispatch } from "../../context/DatasetContext";
+import {
+  useSettings,
+  useSettingsDispatch,
+} from "../../context/SettingsContext";
 
 export function ViolinControls() {
-  const dataset = useDataset();
-  const dispatch = useDatasetDispatch();
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
 
   const scaleList = _.values(VIOLINPLOT_SCALES).map((scale) => (
     <Dropdown.Item
       key={scale.value}
-      active={dataset.controls.scale.violinplot === scale}
+      active={settings.controls.scale.violinplot === scale}
       onClick={() => {
         dispatch({
           type: "set.controls.scale",
@@ -38,7 +41,7 @@ export function ViolinControls() {
           <InputGroup.Text>Scale</InputGroup.Text>
           <Dropdown>
             <Dropdown.Toggle id="dropdownStandardScale" variant="light">
-              {dataset.controls.scale.violinplot.name}
+              {settings.controls.scale.violinplot.name}
             </Dropdown.Toggle>
             <Dropdown.Menu>{scaleList}</Dropdown.Menu>
           </Dropdown>

--- a/src/lib/context/DatasetContext.js
+++ b/src/lib/context/DatasetContext.js
@@ -1,4 +1,4 @@
-import React, { useEffect, createContext, useContext, useReducer } from "react";
+import React, { createContext, useContext } from "react";
 
 import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
 import { QueryClient, QueryCache } from "@tanstack/react-query";
@@ -6,21 +6,11 @@ import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client
 import _ from "lodash";
 
 import { FilterProvider } from "./FilterContext";
+import { SettingsProvider } from "./SettingsContext";
 import { ZarrDataProvider } from "./ZarrDataContext";
-import {
-  COLOR_ENCODINGS,
-  DOTPLOT_SCALES,
-  LOCAL_STORAGE_KEY,
-  MATRIXPLOT_SCALES,
-  OBS_TYPES,
-  PSEUDOSPATIAL_CATEGORICAL_MODES,
-  VAR_SORT,
-  VAR_SORT_ORDER,
-  VIOLINPLOT_SCALES,
-} from "../constants/constants";
 
 export const DatasetContext = createContext(null);
-export const DatasetDispatchContext = createContext(null);
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -59,89 +49,28 @@ const persistOptions = {
 };
 
 const initialDataset = {
+  url: null,
   varNamesCol: null,
-  selectedObs: null,
-  selectedObsm: null,
-  selectedVar: null,
-  selectedMultiObs: [],
-  selectedMultiVar: [],
-  colorEncoding: null,
-  labelObs: [],
-  varSets: [],
-  sliceBy: { obs: false, polygons: false },
-  controls: {
-    colorScale: "Viridis",
-    valueRange: [0, 1],
-    range: [0, 1],
-    colorAxis: { dmin: 0, dmax: 1, cmin: 0, cmax: 1 },
-    scale: {
-      dotplot: DOTPLOT_SCALES.NONE,
-      matrixplot: MATRIXPLOT_SCALES.NONE,
-      violinplot: VIOLINPLOT_SCALES.WIDTH,
-    },
-    meanOnlyExpressed: false,
-    expressionCutoff: 0.0,
-  },
   diseaseDatasets: [],
-  selectedDisease: null,
-  varSort: {
-    var: { sort: VAR_SORT.NONE, sortOrder: VAR_SORT_ORDER.ASC },
-    disease: { sort: VAR_SORT.NONE, sortOrder: VAR_SORT_ORDER.ASC },
-  },
   obsGroups: null,
   imageUrl: null,
-  pseudospatial: {
-    maskSet: null,
-    maskValues: null,
-    categoricalMode: PSEUDOSPATIAL_CATEGORICAL_MODES.ACROSS.value,
-  },
-  polygons: {},
-};
-
-const initializer = (initialState) => {
-  const localObj =
-    (JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY)) || {})[
-      initialState.url
-    ] || {};
-  const keys = _.keys(initialState);
-  const localValues = _.pick(localObj, keys);
-  return _.assign(initialState, localValues);
+  defaultSettings: {},
+  canOverrideSettings: true,
 };
 
 export function DatasetProvider({ dataset_url, children, ...dataset_params }) {
-  const [dataset, dispatch] = useReducer(
-    datasetReducer,
-    _.assign(
-      initializer({ url: dataset_url, ...initialDataset }),
-      dataset_params
-    )
-  );
-
-  useEffect(() => {
-    try {
-      const localObj =
-        JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY)) || {};
-      localStorage.setItem(
-        LOCAL_STORAGE_KEY,
-        JSON.stringify({ ...localObj, [dataset.url]: dataset })
-      );
-    } catch (err) {
-      if (
-        err.code === 22 ||
-        err.code === 1014 ||
-        err.name === "QuotaExceededError" ||
-        err.name === "NS_ERROR_DOM_QUOTA_REACHED"
-      ) {
-        console.err("Browser storage quota exceeded");
-      } else {
-        console.err(err);
-      }
-    }
-  }, [dataset]);
+  const dataset = _.assign(initialDataset, {
+    url: dataset_url,
+    ...dataset_params,
+  });
 
   return (
     <DatasetContext.Provider value={dataset}>
-      <DatasetDispatchContext.Provider value={dispatch}>
+      <SettingsProvider
+        dataset_url={dataset.url}
+        defaultSettings={dataset.defaultSettings}
+        canOverrideSettings={dataset.canOverrideSettings}
+      >
         <PersistQueryClientProvider
           client={queryClient}
           persistOptions={persistOptions}
@@ -150,345 +79,11 @@ export function DatasetProvider({ dataset_url, children, ...dataset_params }) {
             <ZarrDataProvider>{children}</ZarrDataProvider>
           </FilterProvider>
         </PersistQueryClientProvider>
-      </DatasetDispatchContext.Provider>
+      </SettingsProvider>
     </DatasetContext.Provider>
   );
 }
 
 export function useDataset() {
   return useContext(DatasetContext);
-}
-
-export function useDatasetDispatch() {
-  return useContext(DatasetDispatchContext);
-}
-
-function datasetReducer(dataset, action) {
-  switch (action.type) {
-    case "select.obs": {
-      return {
-        ...dataset,
-        selectedObs: action.obs,
-        controls: {
-          ...dataset.controls,
-          range:
-            action.obs?.type === OBS_TYPES.CATEGORICAL
-              ? [0, 1]
-              : dataset.controls.range,
-        },
-        colorEncoding:
-          dataset.colorEncoding === COLOR_ENCODINGS.OBS && !action.obs
-            ? null
-            : dataset.colorEncoding,
-        sliceBy: {
-          ...dataset.sliceBy,
-          obs: action.obs ? dataset.sliceBy.obs : false,
-        },
-      };
-    }
-    case "select.obsm": {
-      return { ...dataset, selectedObsm: action.obsm };
-    }
-    case "select.var": {
-      return { ...dataset, selectedVar: action.var };
-    }
-    case "select.multivar": {
-      if (
-        dataset.selectedMultiVar.find((i) =>
-          action.var.isSet
-            ? i.name === action.var.name
-            : i.matrix_index === action.var.matrix_index
-        )
-      ) {
-        return dataset;
-      } else {
-        return {
-          ...dataset,
-          selectedMultiVar: [...dataset.selectedMultiVar, action.var],
-        };
-      }
-    }
-    case "deselect.multivar": {
-      return {
-        ...dataset,
-        selectedMultiVar: dataset.selectedMultiVar.filter((a) =>
-          action.var.isSet
-            ? a.name !== action.var.name
-            : a.matrix_index !== action.var.matrix_index
-        ),
-      };
-    }
-    case "update.multivar": {
-      return {
-        ...dataset,
-        selelectedMultiVar: dataset.selectedMultiVar.map((i) => {
-          if (i.isSet) {
-            return action.vars.find((s) => s.name === i.name);
-          }
-          return i;
-        }),
-      };
-    }
-    case "set.colorEncoding": {
-      return { ...dataset, colorEncoding: action.value };
-    }
-    case "reset.multiVar": {
-      return {
-        ...dataset,
-        selectedMultiVar: [],
-        colorEncoding:
-          dataset.colorEncoding === COLOR_ENCODINGS.VAR
-            ? null
-            : dataset.colorEncoding,
-      };
-    }
-    case "reset.var": {
-      return {
-        ...dataset,
-        selectedVar: null,
-        colorEncoding:
-          dataset.colorEncoding === COLOR_ENCODINGS.VAR
-            ? null
-            : dataset.colorEncoding,
-      };
-    }
-    case "add.varSet": {
-      return { ...dataset, varSets: [...dataset.varSets, action.varSet] };
-    }
-    case "remove.varSet": {
-      return {
-        ...dataset,
-        varSets: dataset.varSets.filter((a) => a.name !== action.varSet.name),
-      };
-    }
-    case "reset.varSets": {
-      return { ...dataset, varSets: [] };
-    }
-    case "add.varSet.var": {
-      const varSet = dataset.varSets.find((s) => s.name === action.varSet.name);
-      if (varSet.vars.find((v) => _.isEqual(v, action.var))) {
-        return dataset;
-      } else {
-        return {
-          ...dataset,
-          varSets: dataset.varSets.map((s) => {
-            if (s.name === varSet.name) {
-              return { ...s, vars: [...s.vars, action.var] };
-            } else {
-              return s;
-            }
-          }),
-        };
-      }
-    }
-    case "remove.varSet.var": {
-      const varSet = dataset.varSets.find((s) => s.name === action.varSet.name);
-      return {
-        ...dataset,
-        varSets: dataset.varSets.map((s) => {
-          if (s.name === varSet.name) {
-            return {
-              ...s,
-              vars: s.vars.filter((v) => v.name !== action.var.name),
-            };
-          } else {
-            return s;
-          }
-        }),
-      };
-    }
-    case "select.disease": {
-      return {
-        ...dataset,
-        selectedDisease: { id: action.id, name: action.name },
-      };
-    }
-    case "reset.disease": {
-      return { ...dataset, selectedDisease: null };
-    }
-    case "set.controls.colorScale": {
-      return {
-        ...dataset,
-        controls: { ...dataset.controls, colorScale: action.colorScale },
-      };
-    }
-    case "set.controls.valueRange": {
-      return {
-        ...dataset,
-        controls: { ...dataset.controls, valueRange: action.valueRange },
-      };
-    }
-    case "set.controls.range": {
-      return {
-        ...dataset,
-        controls: { ...dataset.controls, range: action.range },
-      };
-    }
-    case "set.controls.colorAxis": {
-      return {
-        ...dataset,
-        controls: { ...dataset.controls, colorAxis: action.colorAxis },
-      };
-    }
-    case "set.controls.colorAxis.crange": {
-      return {
-        ...dataset,
-        controls: {
-          ...dataset.controls,
-          colorAxis: {
-            ...dataset.controls.colorAxis,
-            cmin: action.cmin,
-            cmax: action.cmax,
-          },
-        },
-      };
-    }
-    case "set.controls.colorAxis.cmin": {
-      return {
-        ...dataset,
-        controls: {
-          ...dataset.controls,
-          colorAxis: { ...dataset.controls.colorAxis, cmin: action.cmin },
-        },
-      };
-    }
-    case "set.controls.colorAxis.cmax": {
-      return {
-        ...dataset,
-        controls: {
-          ...dataset.controls,
-          colorAxis: { ...dataset.controls.colorAxis, cmax: action.cmax },
-        },
-      };
-    }
-    case "set.controls.scale": {
-      return {
-        ...dataset,
-        controls: {
-          ...dataset.controls,
-          scale: { ...dataset.controls.scale, [action.plot]: action.scale },
-        },
-      };
-    }
-    case "set.controls.meanOnlyExpressed": {
-      return {
-        ...dataset,
-        controls: {
-          ...dataset.controls,
-          meanOnlyExpressed: action.meanOnlyExpressed,
-        },
-      };
-    }
-    case "set.controls.expressionCutoff": {
-      return {
-        ...dataset,
-        controls: {
-          ...dataset.controls,
-          expressionCutoff: action.expressionCutoff,
-        },
-      };
-    }
-    case "toggle.slice.obs": {
-      if (_.isEqual(dataset.selectedObs, action.obs)) {
-        return {
-          ...dataset,
-          sliceBy: { ...dataset.sliceBy, obs: !dataset.sliceBy.obs },
-        };
-      } else {
-        return {
-          ...dataset,
-          selectedObs: action.obs,
-          sliceBy: { ...dataset.sliceBy, obs: true },
-        };
-      }
-    }
-    case "toggle.slice.polygons": {
-      return {
-        ...dataset,
-        sliceBy: { ...dataset.sliceBy, polygons: !dataset.sliceBy.polygons },
-      };
-    }
-    case "disable.slice.polygons": {
-      return { ...dataset, sliceBy: { ...dataset.sliceBy, polygons: false } };
-    }
-    case "add.label.obs": {
-      if (dataset.labelObs.find((i) => _.isEqual(i, action.obs))) {
-        return dataset;
-      } else {
-        return { ...dataset, labelObs: [...dataset.labelObs, action.obs] };
-      }
-    }
-    case "remove.label.obs": {
-      return {
-        ...dataset,
-        labelObs: dataset.labelObs.filter((a) => a.name !== action.obsName),
-      };
-    }
-    case "reset.label.obs": {
-      return { ...dataset, labelObs: [] };
-    }
-    case "set.varSort": {
-      return {
-        ...dataset,
-        varSort: {
-          ...dataset.varSort,
-          [action.var]: { sort: action.sort, sortOrder: action.sortOrder },
-        },
-      };
-    }
-    case "set.varSort.sort": {
-      return {
-        ...dataset,
-        varSort: {
-          ...dataset.varSort,
-          [action.var]: { ...dataset.varSort[action.var], sort: action.sort },
-        },
-      };
-    }
-    case "set.varSort.sortOrder": {
-      return {
-        ...dataset,
-        varSort: {
-          ...dataset.varSort,
-          [action.var]: {
-            ...dataset.varSort[action.var],
-            sortOrder: action.sortOrder,
-          },
-        },
-      };
-    }
-    case "set.polygons": {
-      return {
-        ...dataset,
-        polygons: { ...dataset.polygons, [action.obsm]: action.polygons },
-      };
-    }
-    case "set.pseudospatial.maskSet": {
-      return {
-        ...dataset,
-        pseudospatial: { ...dataset.pseudospatial, maskSet: action.maskSet },
-      };
-    }
-    case "set.pseudospatial.maskValues": {
-      return {
-        ...dataset,
-        pseudospatial: {
-          ...dataset.pseudospatial,
-          maskValues: action.maskValues,
-        },
-      };
-    }
-    case "set.pseudospatial.categoricalMode": {
-      return {
-        ...dataset,
-        pseudospatial: {
-          ...dataset.pseudospatial,
-          categoricalMode: action.categoricalMode,
-        },
-      };
-    }
-    default: {
-      throw Error("Unknown action: " + action.type);
-    }
-  }
 }

--- a/src/lib/context/SettingsContext.js
+++ b/src/lib/context/SettingsContext.js
@@ -224,7 +224,7 @@ function settingsReducer(settings, action) {
       };
     }
     case "add.var": {
-      if (settings.vars.find((v) => _.isEqual(v, action.var))) {
+      if (settings.vars.find((v) => v.name === action.var.name)) {
         return settings;
       } else {
         return { ...settings, vars: [...settings.vars, action.var] };
@@ -249,18 +249,36 @@ function settingsReducer(settings, action) {
       const varSet = settings.vars.find(
         (s) => s.isSet && s.name === action.varSet.name
       );
-      if (varSet.vars.find((v) => _.isEqual(v, action.var))) {
+      if (!varSet) {
+        return settings;
+      }
+      if (varSet.vars.some((v) => v.name === action.var.name)) {
         return settings;
       } else {
+        const varSetVars = [...varSet.vars, action.var];
+        const vars = settings.vars.map((v) => {
+          if (v.name === varSet.name) {
+            return { ...v, vars: varSetVars };
+          } else {
+            return v;
+          }
+        });
+        const selectedVar =
+          settings.selectedVar?.name === action.varSet.name
+            ? { ...varSet, vars: varSetVars }
+            : settings.selectedVar;
+        const selectedMultiVar = settings.selectedMultiVar.map((v) => {
+          if (v.name === varSet.name) {
+            return { ...v, vars: varSetVars };
+          } else {
+            return v;
+          }
+        });
         return {
           ...settings,
-          vars: settings.vars.map((s) => {
-            if (s.name === varSet.name) {
-              return { ...s, vars: [...s.vars, action.var] };
-            } else {
-              return s;
-            }
-          }),
+          vars: vars,
+          selectedVar: selectedVar,
+          selectedMultiVar: selectedMultiVar,
         };
       }
     }
@@ -268,19 +286,40 @@ function settingsReducer(settings, action) {
       const varSet = settings.vars.find(
         (s) => s.isSet && s.name === action.varSet.name
       );
-      return {
-        ...settings,
-        vars: settings.vars.map((s) => {
-          if (s.name === varSet.name) {
-            return {
-              ...s,
-              vars: s.vars.filter((v) => v.name !== action.var.name),
-            };
+      if (!varSet) {
+        return settings;
+      }
+      if (!varSet.vars.some((v) => v.name === action.var.name)) {
+        return settings;
+      } else {
+        const varSetVars = varSet.vars.filter(
+          (v) => v.name !== action.var.name
+        );
+        const vars = settings.vars.map((v) => {
+          if (v.name === varSet.name) {
+            return { ...v, vars: varSetVars };
           } else {
-            return s;
+            return v;
           }
-        }),
-      };
+        });
+        const selectedVar =
+          settings.selectedVar?.name === action.varSet.name
+            ? { ...varSet, vars: varSetVars }
+            : settings.selectedVar;
+        const selectedMultiVar = settings.selectedMultiVar.map((v) => {
+          if (v.name === varSet.name) {
+            return { ...v, vars: varSetVars };
+          } else {
+            return v;
+          }
+        });
+        return {
+          ...settings,
+          vars: vars,
+          selectedVar: selectedVar,
+          selectedMultiVar: selectedMultiVar,
+        };
+      }
     }
     case "set.controls.colorScale": {
       return {

--- a/src/lib/context/SettingsContext.js
+++ b/src/lib/context/SettingsContext.js
@@ -1,0 +1,433 @@
+import { createContext, useContext, useEffect, useReducer } from "react";
+
+import { useLocalStorage } from "@uidotdev/usehooks";
+import _ from "lodash";
+
+import {
+  COLOR_ENCODINGS,
+  DOTPLOT_SCALES,
+  LOCAL_STORAGE_KEY,
+  MATRIXPLOT_SCALES,
+  OBS_TYPES,
+  PSEUDOSPATIAL_CATEGORICAL_MODES,
+  VAR_SORT,
+  VAR_SORT_ORDER,
+  VIOLINPLOT_SCALES,
+} from "../constants/constants";
+
+export const SettingsContext = createContext(null);
+export const SettingsDispatchContext = createContext(null);
+
+const initialSettings = {
+  selectedObs: null,
+  selectedVar: null,
+  selectedObsm: null,
+  selectedMultiObs: [],
+  selectedMultiVar: [],
+  colorEncoding: null,
+  labelObs: [],
+  varSets: [],
+  sliceBy: { obs: false, polygons: false },
+  polygons: {},
+  controls: {
+    colorScale: "Viridis",
+    valueRange: [0, 1],
+    range: [0, 1],
+    colorAxis: { dmin: 0, dmax: 1, cmin: 0, cmax: 1 },
+    scale: {
+      dotplot: DOTPLOT_SCALES.NONE,
+      matrixplot: MATRIXPLOT_SCALES.NONE,
+      violinplot: VIOLINPLOT_SCALES.WIDTH,
+    },
+    meanOnlyExpressed: false,
+    expressionCutoff: 0.0,
+  },
+  varSort: {
+    var: { sort: VAR_SORT.NONE, sortOrder: VAR_SORT_ORDER.ASC },
+    disease: { sort: VAR_SORT.NONE, sortOrder: VAR_SORT_ORDER.ASC },
+  },
+  pseudospatial: {
+    maskSet: null,
+    maskValues: null,
+    categoricalMode: PSEUDOSPATIAL_CATEGORICAL_MODES.ACROSS.value,
+  },
+};
+
+export function SettingsProvider({
+  dataset_url,
+  defaultSettings,
+  canOverrideSettings,
+  children,
+}) {
+  const DATASET_STORAGE_KEY = `${LOCAL_STORAGE_KEY}-${dataset_url}`;
+  const [localSettings, setLocalSettings] = useLocalStorage(
+    DATASET_STORAGE_KEY,
+    {}
+  );
+  const [settings, dispatch] = useReducer(
+    settingsReducer,
+    canOverrideSettings
+      ? _.assign(initialSettings, defaultSettings, localSettings)
+      : _.assign(initialSettings, defaultSettings)
+  );
+
+  useEffect(() => {
+    try {
+      if (canOverrideSettings) {
+        setLocalSettings(settings);
+      }
+    } catch (err) {
+      if (
+        err.code === 22 ||
+        err.code === 1014 ||
+        err.name === "QuotaExceededError" ||
+        err.name === "NS_ERROR_DOM_QUOTA_REACHED"
+      ) {
+        console.err("Browser storage quota exceeded");
+      } else {
+        console.err(err);
+      }
+    }
+  }, [canOverrideSettings, setLocalSettings, settings]);
+
+  return (
+    <SettingsContext.Provider value={settings}>
+      <SettingsDispatchContext.Provider value={dispatch}>
+        {children}
+      </SettingsDispatchContext.Provider>
+    </SettingsContext.Provider>
+  );
+}
+
+export function useSettings() {
+  return useContext(SettingsContext);
+}
+
+export function useSettingsDispatch() {
+  return useContext(SettingsDispatchContext);
+}
+
+function settingsReducer(settings, action) {
+  switch (action.type) {
+    case "select.obs": {
+      return {
+        ...settings,
+        selectedObs: action.obs,
+        controls: {
+          ...settings.controls,
+          range:
+            action.obs?.type === OBS_TYPES.CATEGORICAL
+              ? [0, 1]
+              : settings.controls.range,
+        },
+        colorEncoding:
+          settings.colorEncoding === COLOR_ENCODINGS.OBS && !action.obs
+            ? null
+            : settings.colorEncoding,
+        sliceBy: {
+          ...settings.sliceBy,
+          obs: action.obs ? settings.sliceBy.obs : false,
+        },
+      };
+    }
+    case "select.obsm": {
+      return { ...settings, selectedObsm: action.obsm };
+    }
+    case "select.var": {
+      return { ...settings, selectedVar: action.var };
+    }
+    case "select.multivar": {
+      if (
+        settings.selectedMultiVar.find((i) =>
+          action.var.isSet
+            ? i.name === action.var.name
+            : i.matrix_index === action.var.matrix_index
+        )
+      ) {
+        return settings;
+      } else {
+        return {
+          ...settings,
+          selectedMultiVar: [...settings.selectedMultiVar, action.var],
+        };
+      }
+    }
+    case "deselect.multivar": {
+      return {
+        ...settings,
+        selectedMultiVar: settings.selectedMultiVar.filter((a) =>
+          action.var.isSet
+            ? a.name !== action.var.name
+            : a.matrix_index !== action.var.matrix_index
+        ),
+      };
+    }
+    case "update.multivar": {
+      return {
+        ...settings,
+        selelectedMultiVar: settings.selectedMultiVar.map((i) => {
+          if (i.isSet) {
+            return action.vars.find((s) => s.name === i.name);
+          }
+          return i;
+        }),
+      };
+    }
+    case "set.colorEncoding": {
+      return { ...settings, colorEncoding: action.value };
+    }
+    case "reset.multiVar": {
+      return {
+        ...settings,
+        selectedMultiVar: [],
+        colorEncoding:
+          settings.colorEncoding === COLOR_ENCODINGS.VAR
+            ? null
+            : settings.colorEncoding,
+      };
+    }
+    case "reset.var": {
+      return {
+        ...settings,
+        selectedVar: null,
+        colorEncoding:
+          settings.colorEncoding === COLOR_ENCODINGS.VAR
+            ? null
+            : settings.colorEncoding,
+      };
+    }
+    case "add.varSet": {
+      return { ...settings, varSets: [...settings.varSets, action.varSet] };
+    }
+    case "remove.varSet": {
+      return {
+        ...settings,
+        varSets: settings.varSets.filter((a) => a.name !== action.varSet.name),
+      };
+    }
+    case "reset.varSets": {
+      return { ...settings, varSets: [] };
+    }
+    case "add.varSet.var": {
+      const varSet = settings.varSets.find(
+        (s) => s.name === action.varSet.name
+      );
+      if (varSet.vars.find((v) => _.isEqual(v, action.var))) {
+        return settings;
+      } else {
+        return {
+          ...settings,
+          varSets: settings.varSets.map((s) => {
+            if (s.name === varSet.name) {
+              return { ...s, vars: [...s.vars, action.var] };
+            } else {
+              return s;
+            }
+          }),
+        };
+      }
+    }
+    case "remove.varSet.var": {
+      const varSet = settings.varSets.find(
+        (s) => s.name === action.varSet.name
+      );
+      return {
+        ...settings,
+        varSets: settings.varSets.map((s) => {
+          if (s.name === varSet.name) {
+            return {
+              ...s,
+              vars: s.vars.filter((v) => v.name !== action.var.name),
+            };
+          } else {
+            return s;
+          }
+        }),
+      };
+    }
+    case "set.controls.colorScale": {
+      return {
+        ...settings,
+        controls: { ...settings.controls, colorScale: action.colorScale },
+      };
+    }
+    case "set.controls.valueRange": {
+      return {
+        ...settings,
+        controls: { ...settings.controls, valueRange: action.valueRange },
+      };
+    }
+    case "set.controls.range": {
+      return {
+        ...settings,
+        controls: { ...settings.controls, range: action.range },
+      };
+    }
+    case "set.controls.colorAxis": {
+      return {
+        ...settings,
+        controls: { ...settings.controls, colorAxis: action.colorAxis },
+      };
+    }
+    case "set.controls.colorAxis.crange": {
+      return {
+        ...settings,
+        controls: {
+          ...settings.controls,
+          colorAxis: {
+            ...settings.controls.colorAxis,
+            cmin: action.cmin,
+            cmax: action.cmax,
+          },
+        },
+      };
+    }
+    case "set.controls.colorAxis.cmin": {
+      return {
+        ...settings,
+        controls: {
+          ...settings.controls,
+          colorAxis: { ...settings.controls.colorAxis, cmin: action.cmin },
+        },
+      };
+    }
+    case "set.controls.colorAxis.cmax": {
+      return {
+        ...settings,
+        controls: {
+          ...settings.controls,
+          colorAxis: { ...settings.controls.colorAxis, cmax: action.cmax },
+        },
+      };
+    }
+    case "set.controls.scale": {
+      return {
+        ...settings,
+        controls: {
+          ...settings.controls,
+          scale: { ...settings.controls.scale, [action.plot]: action.scale },
+        },
+      };
+    }
+    case "set.controls.meanOnlyExpressed": {
+      return {
+        ...settings,
+        controls: {
+          ...settings.controls,
+          meanOnlyExpressed: action.meanOnlyExpressed,
+        },
+      };
+    }
+    case "set.controls.expressionCutoff": {
+      return {
+        ...settings,
+        controls: {
+          ...settings.controls,
+          expressionCutoff: action.expressionCutoff,
+        },
+      };
+    }
+    case "toggle.slice.obs": {
+      if (_.isEqual(settings.selectedObs, action.obs)) {
+        return {
+          ...settings,
+          sliceBy: { ...settings.sliceBy, obs: !settings.sliceBy.obs },
+        };
+      } else {
+        return {
+          ...settings,
+          selectedObs: action.obs,
+          sliceBy: { ...settings.sliceBy, obs: true },
+        };
+      }
+    }
+    case "toggle.slice.polygons": {
+      return {
+        ...settings,
+        sliceBy: { ...settings.sliceBy, polygons: !settings.sliceBy.polygons },
+      };
+    }
+    case "disable.slice.polygons": {
+      return { ...settings, sliceBy: { ...settings.sliceBy, polygons: false } };
+    }
+    case "add.label.obs": {
+      if (settings.labelObs.find((i) => _.isEqual(i, action.obs))) {
+        return settings;
+      } else {
+        return { ...settings, labelObs: [...settings.labelObs, action.obs] };
+      }
+    }
+    case "remove.label.obs": {
+      return {
+        ...settings,
+        labelObs: settings.labelObs.filter((a) => a.name !== action.obsName),
+      };
+    }
+    case "reset.label.obs": {
+      return { ...settings, labelObs: [] };
+    }
+    case "set.varSort": {
+      return {
+        ...settings,
+        varSort: {
+          ...settings.varSort,
+          [action.var]: { sort: action.sort, sortOrder: action.sortOrder },
+        },
+      };
+    }
+    case "set.varSort.sort": {
+      return {
+        ...settings,
+        varSort: {
+          ...settings.varSort,
+          [action.var]: { ...settings.varSort[action.var], sort: action.sort },
+        },
+      };
+    }
+    case "set.varSort.sortOrder": {
+      return {
+        ...settings,
+        varSort: {
+          ...settings.varSort,
+          [action.var]: {
+            ...settings.varSort[action.var],
+            sortOrder: action.sortOrder,
+          },
+        },
+      };
+    }
+    case "set.polygons": {
+      return {
+        ...settings,
+        polygons: { ...settings.polygons, [action.obsm]: action.polygons },
+      };
+    }
+    case "set.pseudospatial.maskSet": {
+      return {
+        ...settings,
+        pseudospatial: { ...settings.pseudospatial, maskSet: action.maskSet },
+      };
+    }
+    case "set.pseudospatial.maskValues": {
+      return {
+        ...settings,
+        pseudospatial: {
+          ...settings.pseudospatial,
+          maskValues: action.maskValues,
+        },
+      };
+    }
+    case "set.pseudospatial.categoricalMode": {
+      return {
+        ...settings,
+        pseudospatial: {
+          ...settings.pseudospatial,
+          categoricalMode: action.categoricalMode,
+        },
+      };
+    }
+    default: {
+      throw Error("Unknown action: " + action.type);
+    }
+  }
+}

--- a/src/lib/context/SettingsContext.js
+++ b/src/lib/context/SettingsContext.js
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useReducer } from "react";
+import React, { createContext, useContext, useEffect, useReducer } from "react";
 
 import _ from "lodash";
 

--- a/src/lib/context/SettingsContext.js
+++ b/src/lib/context/SettingsContext.js
@@ -302,23 +302,41 @@ function settingsReducer(settings, action) {
             return v;
           }
         });
-        const selectedVar =
-          settings.selectedVar?.name === action.varSet.name
-            ? { ...varSet, vars: varSetVars }
-            : settings.selectedVar;
-        const selectedMultiVar = settings.selectedMultiVar.map((v) => {
-          if (v.name === varSet.name) {
-            return { ...v, vars: varSetVars };
-          } else {
-            return v;
-          }
-        });
-        return {
-          ...settings,
-          vars: vars,
-          selectedVar: selectedVar,
-          selectedMultiVar: selectedMultiVar,
-        };
+        // Remove from selected if varSet vars is empty
+        if (!varSetVars.length) {
+          const selectedVar =
+            settings.selectedVar?.name === action.varSet.name
+              ? null
+              : settings.selectedVar;
+          const selectedMultiVar = settings.selectedMultiVar.filter(
+            (v) => v.name !== action.varSet.name
+          );
+          return {
+            ...settings,
+            vars: vars,
+            selectedVar: selectedVar,
+            selectedMultiVar: selectedMultiVar,
+          };
+        } else {
+          // Update selected if varSet is selected
+          const selectedVar =
+            settings.selectedVar?.name === action.varSet.name
+              ? { ...varSet, vars: varSetVars }
+              : settings.selectedVar;
+          const selectedMultiVar = settings.selectedMultiVar.map((v) => {
+            if (v.name === varSet.name) {
+              return { ...v, vars: varSetVars };
+            } else {
+              return v;
+            }
+          });
+          return {
+            ...settings,
+            vars: vars,
+            selectedVar: selectedVar,
+            selectedMultiVar: selectedMultiVar,
+          };
+        }
       }
     }
     case "set.controls.colorScale": {

--- a/src/lib/helpers/color-helper.js
+++ b/src/lib/helpers/color-helper.js
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 
 import { COLORSCALES } from "../constants/colorscales";
-import { useDataset } from "../context/DatasetContext";
+import { useSettings } from "../context/SettingsContext";
 
 const GRAY = [214, 212, 212];
 
@@ -44,7 +44,7 @@ export const rgbToHex = (color) => {
 };
 
 export const useColor = () => {
-  const dataset = useDataset();
+  const settings = useSettings();
 
   const getColor = useCallback(
     ({
@@ -52,12 +52,12 @@ export const useColor = () => {
       categorical = false,
       grayOut = false,
       grayParams: { alpha = 0.75, gray = 0.95 } = {},
-      colorEncoding = dataset.colorEncoding,
+      colorEncoding = settings.colorEncoding,
       colorscale = null,
     }) => {
       const colormap =
         colorscale ||
-        COLORSCALES[categorical ? "Accent" : dataset.controls.colorScale];
+        COLORSCALES[categorical ? "Accent" : settings.controls.colorScale];
       if (colorEncoding) {
         if (grayOut) {
           // Mix color with gray manually instead of chroma.mix to get better performance with deck.gl
@@ -75,7 +75,7 @@ export const useColor = () => {
         return null;
       }
     },
-    [dataset.colorEncoding, dataset.controls.colorScale]
+    [settings.colorEncoding, settings.controls.colorScale]
   );
 
   return { getColor };

--- a/src/lib/utils/Legend.js
+++ b/src/lib/utils/Legend.js
@@ -4,10 +4,10 @@ import { faDroplet } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import _ from "lodash";
 
-import { COLOR_ENCODINGS } from "../constants/constants";
-import { useDataset } from "../context/DatasetContext";
-import { rgbToHex, useColor } from "../helpers/color-helper";
 import { formatNumerical, FORMATS } from "./string";
+import { COLOR_ENCODINGS } from "../constants/constants";
+import { useSettings } from "../context/SettingsContext";
+import { rgbToHex, useColor } from "../helpers/color-helper";
 
 export function Legend({
   isCategorical = false,
@@ -16,7 +16,7 @@ export function Legend({
   colorscale = null,
   addText = "",
 }) {
-  const dataset = useDataset();
+  const settings = useSettings();
   const { getColor } = useColor();
 
   const spanList = useMemo(() => {
@@ -38,15 +38,15 @@ export function Legend({
     });
   }, [colorscale, getColor, isCategorical]);
 
-  if (dataset.colorEncoding && !isCategorical) {
+  if (settings.colorEncoding && !isCategorical) {
     return (
       <div className="cherita-legend">
         <div className="gradient">
           <p className="small m-0 p-0">
             <FontAwesomeIcon icon={faDroplet} className="me-1" />
-            {(dataset.colorEncoding === COLOR_ENCODINGS.VAR
-              ? dataset.selectedVar?.name
-              : dataset.selectedObs?.name) + addText}
+            {(settings.colorEncoding === COLOR_ENCODINGS.VAR
+              ? settings.selectedVar?.name
+              : settings.selectedObs?.name) + addText}
           </p>
           {spanList}
           <span className="domain-min">
@@ -62,14 +62,14 @@ export function Legend({
       </div>
     );
   } else if (
-    dataset.colorEncoding === COLOR_ENCODINGS.OBS &&
-    dataset.selectedObs
+    settings.colorEncoding === COLOR_ENCODINGS.OBS &&
+    settings.selectedObs
   ) {
     return (
       <div className="cherita-legend categorical">
         <p className="legend-text text-end m-0 p-0">
           <FontAwesomeIcon icon={faDroplet} className="me-2" />
-          {dataset.selectedObs.name}
+          {settings.selectedObs.name}
         </p>
       </div>
     );

--- a/src/lib/utils/zarrData.js
+++ b/src/lib/utils/zarrData.js
@@ -5,13 +5,15 @@ import { slice } from "zarr";
 
 import { OBS_TYPES } from "../constants/constants";
 import { useDataset } from "../context/DatasetContext";
+import { useSettings } from "../context/SettingsContext";
 import { GET_OPTIONS, useZarr, useMultipleZarr } from "../helpers/zarr-helper";
 
 // @TODO: support specifying slice to load from context
 export const useObsmData = (obsm = null) => {
   const dataset = useDataset();
+  const settings = useSettings();
 
-  obsm = obsm || dataset.selectedObsm;
+  obsm = obsm || settings.selectedObsm;
 
   const [obsmParams, setObsmParams] = useState({
     url: dataset.url,
@@ -36,40 +38,41 @@ const meanData = (_i, data) => {
 
 export const useXData = (agg = meanData) => {
   const dataset = useDataset();
+  const settings = useSettings();
 
   const [xParams, setXParams] = useState(
-    !dataset.selectedVar
+    !settings.selectedVar
       ? []
-      : !dataset.selectedVar?.isSet
+      : !settings.selectedVar?.isSet
         ? [
             {
               url: dataset.url,
               path: "X",
-              s: [null, dataset.selectedVar?.matrix_index],
+              s: [null, settings.selectedVar?.matrix_index],
             },
           ]
-        : _.map(dataset.selectedVar?.vars, (v) => {
+        : _.map(settings.selectedVar?.vars, (v) => {
             return { url: dataset.url, path: "X", s: [null, v.matrix_index] };
           })
   );
 
   useEffect(() => {
     setXParams(
-      !dataset.selectedVar
+      !settings.selectedVar
         ? []
-        : !dataset.selectedVar?.isSet
+        : !settings.selectedVar?.isSet
           ? [
               {
                 url: dataset.url,
                 path: "X",
-                s: [null, dataset.selectedVar?.matrix_index],
+                s: [null, settings.selectedVar?.matrix_index],
               },
             ]
-          : _.map(dataset.selectedVar?.vars, (v) => {
+          : _.map(settings.selectedVar?.vars, (v) => {
               return { url: dataset.url, path: "X", s: [null, v.matrix_index] };
             })
     );
-  }, [dataset.url, dataset.selectedVar]);
+  }, [dataset.url, settings.selectedVar]);
 
   return useMultipleZarr(
     xParams,
@@ -81,8 +84,9 @@ export const useXData = (agg = meanData) => {
 
 export const useObsData = (obs = null) => {
   const dataset = useDataset();
+  const settings = useSettings();
 
-  obs = obs || dataset.selectedObs;
+  obs = obs || settings.selectedObs;
 
   const [obsParams, setObsParams] = useState({
     url: dataset.url,
@@ -107,9 +111,10 @@ export const useObsData = (obs = null) => {
 
 export const useLabelObsData = () => {
   const dataset = useDataset();
+  const settings = useSettings();
 
   const [labelObsParams, setLabelObsParams] = useState(
-    _.map(dataset.labelObs, (obs) => {
+    _.map(settings.labelObs, (obs) => {
       return {
         url: dataset.url,
         path:
@@ -123,7 +128,7 @@ export const useLabelObsData = () => {
 
   useEffect(() => {
     setLabelObsParams(
-      _.map(dataset.labelObs, (obs) => {
+      _.map(settings.labelObs, (obs) => {
         return {
           url: dataset.url,
           path:
@@ -134,7 +139,7 @@ export const useLabelObsData = () => {
         };
       })
     );
-  }, [dataset.labelObs, dataset.url]);
+  }, [settings.labelObs, dataset.url]);
 
   return useMultipleZarr(labelObsParams, GET_OPTIONS, {
     enabled: !!labelObsParams.length,

--- a/src/tests/ObsColsList.test.js
+++ b/src/tests/ObsColsList.test.js
@@ -8,14 +8,22 @@ import { ObsColsList } from "../lib/components/obs-list/ObsList";
 
 // Mock the context or props
 const mockDataset = {
-  selectedObs: { name: "mockName" },
+  varNamesCol: null,
+};
+
+const mockSettings = {
+  selectedObs: { name: "obsName" },
 };
 
 const mockDispatch = jest.fn();
 
 jest.mock("../lib/context/DatasetContext", () => ({
   useDataset: () => mockDataset,
-  useDatasetDispatch: () => mockDispatch,
+}));
+
+jest.mock("../lib/context/SettingsContext", () => ({
+  useSettings: () => mockSettings,
+  useSettingsDispatch: () => mockDispatch,
 }));
 
 const queryClient = new QueryClient();


### PR DESCRIPTION
- add `SettingsContext` for dynamic values
- use `DatasetContext` for static values (values that won't change from user selection like dataset url, etc)
- add `defaultSettings` and `canOverrideSettings` to dataset context
  - if `canOverrideSettings == false` localStorage is not used. for pages that need to show preselected data on load always

will require current params passed to cherita to be updated to be passed within `defaultSettings`