### PR TITLE
set fullpage css style 

### DIFF
--- a/sites/demo/src/App.scss
+++ b/sites/demo/src/App.scss
@@ -13,3 +13,14 @@
 );
 
 @import "@haniffalab/cherita-react/scss/cherita";
+
+.App {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  margin: 0;
+}
+
+header {
+  flex-shrink: 0;
+}

--- a/sites/demo/src/containers/DotplotDemo.js
+++ b/sites/demo/src/containers/DotplotDemo.js
@@ -16,33 +16,35 @@ export default function DotplotDemo(props) {
   const [showVars, setShowVars] = useState(false);
   const [showControls, setShowControls] = useState(false);
   return (
-    <Container>
-      <div className="cherita-container">
-        <DatasetProvider {...props}>
-          <Toolbar
-            setShowObs={setShowObs}
-            setShowVars={setShowVars}
-            setShowControls={setShowControls}
-          />
-          <div className="cherita-container-plot">
-            <Dotplot />
-          </div>
-          <OffcanvasObs
-            show={showObs}
-            handleClose={() => setShowObs(false)}
-            showSelectedAsActive={true}
-          />
-          <OffcanvasVars
-            show={showVars}
-            handleClose={() => setShowVars(false)}
-          />
-          <OffcanvasControls
-            show={showControls}
-            handleClose={() => setShowControls(false)}
-            Controls={DotplotControls}
-          />
-        </DatasetProvider>
-      </div>
-    </Container>
+    <div className="h-100">
+      <Container>
+        <div className="cherita-container">
+          <DatasetProvider {...props}>
+            <Toolbar
+              setShowObs={setShowObs}
+              setShowVars={setShowVars}
+              setShowControls={setShowControls}
+            />
+            <div className="cherita-container-plot">
+              <Dotplot />
+            </div>
+            <OffcanvasObs
+              show={showObs}
+              handleClose={() => setShowObs(false)}
+              showSelectedAsActive={true}
+            />
+            <OffcanvasVars
+              show={showVars}
+              handleClose={() => setShowVars(false)}
+            />
+            <OffcanvasControls
+              show={showControls}
+              handleClose={() => setShowControls(false)}
+              Controls={DotplotControls}
+            />
+          </DatasetProvider>
+        </div>
+      </Container>
+    </div>
   );
 }

--- a/sites/demo/src/containers/HeatmapDemo.js
+++ b/sites/demo/src/containers/HeatmapDemo.js
@@ -17,34 +17,36 @@ export default function HeatmapDemo(props) {
   const [showControls, setShowControls] = useState(false);
 
   return (
-    <Container>
-      <div className="cherita-container">
-        <DatasetProvider {...props}>
-          <Toolbar
-            setShowObs={setShowObs}
-            setShowVars={setShowVars}
-            setShowControls={setShowControls}
-          />
-          <div className="cherita-container-plot">
-            <Heatmap />
-          </div>
-          <OffcanvasObs
-            show={showObs}
-            handleClose={() => setShowObs(false)}
-            showColor={false}
-            showSelectedAsActive={true}
-          />
-          <OffcanvasVars
-            show={showVars}
-            handleClose={() => setShowVars(false)}
-          />
-          <OffcanvasControls
-            show={showControls}
-            handleClose={() => setShowControls(false)}
-            Controls={HeatmapControls}
-          />
-        </DatasetProvider>
-      </div>
-    </Container>
+    <div className="h-100">
+      <Container>
+        <div className="cherita-container">
+          <DatasetProvider {...props}>
+            <Toolbar
+              setShowObs={setShowObs}
+              setShowVars={setShowVars}
+              setShowControls={setShowControls}
+            />
+            <div className="cherita-container-plot">
+              <Heatmap />
+            </div>
+            <OffcanvasObs
+              show={showObs}
+              handleClose={() => setShowObs(false)}
+              showColor={false}
+              showSelectedAsActive={true}
+            />
+            <OffcanvasVars
+              show={showVars}
+              handleClose={() => setShowVars(false)}
+            />
+            <OffcanvasControls
+              show={showControls}
+              handleClose={() => setShowControls(false)}
+              Controls={HeatmapControls}
+            />
+          </DatasetProvider>
+        </div>
+      </Container>
+    </div>
   );
 }

--- a/sites/demo/src/containers/MatrixplotDemo.js
+++ b/sites/demo/src/containers/MatrixplotDemo.js
@@ -17,34 +17,36 @@ export default function MatrixplotDemo(props) {
   const [showControls, setShowControls] = useState(false);
 
   return (
-    <Container>
-      <div className="cherita-container">
-        <DatasetProvider {...props}>
-          <Toolbar
-            setShowObs={setShowObs}
-            setShowVars={setShowVars}
-            setShowControls={setShowControls}
-          />
-          <div className="cherita-container-plot">
-            <Matrixplot />
-          </div>
-          <OffcanvasObs
-            show={showObs}
-            handleClose={() => setShowObs(false)}
-            showColor={false}
-            showSelectedAsActive={true}
-          />
-          <OffcanvasVars
-            show={showVars}
-            handleClose={() => setShowVars(false)}
-          />
-          <OffcanvasControls
-            show={showControls}
-            handleClose={() => setShowControls(false)}
-            Controls={MatrixplotControls}
-          />
-        </DatasetProvider>
-      </div>
-    </Container>
+    <div className="h-100">
+      <Container>
+        <div className="cherita-container">
+          <DatasetProvider {...props}>
+            <Toolbar
+              setShowObs={setShowObs}
+              setShowVars={setShowVars}
+              setShowControls={setShowControls}
+            />
+            <div className="cherita-container-plot">
+              <Matrixplot />
+            </div>
+            <OffcanvasObs
+              show={showObs}
+              handleClose={() => setShowObs(false)}
+              showColor={false}
+              showSelectedAsActive={true}
+            />
+            <OffcanvasVars
+              show={showVars}
+              handleClose={() => setShowVars(false)}
+            />
+            <OffcanvasControls
+              show={showControls}
+              handleClose={() => setShowControls(false)}
+              Controls={MatrixplotControls}
+            />
+          </DatasetProvider>
+        </div>
+      </Container>
+    </div>
   );
 }

--- a/sites/demo/src/containers/ScatterplotDemo.js
+++ b/sites/demo/src/containers/ScatterplotDemo.js
@@ -17,29 +17,34 @@ export default function ScatterplotDemo(props) {
   const [showControls, setShowControls] = useState(false);
 
   return (
-    <Container>
-      <div className="cherita-container">
-        <DatasetProvider {...props}>
-          <div className="cherita-container-scatterplot">
-            <Scatterplot
-              setShowObs={setShowObs}
-              setShowVars={setShowVars}
-              isFullscreen={false}
+    <div className="h-100">
+      <Container>
+        <div className="cherita-container">
+          <DatasetProvider {...props}>
+            <div className="cherita-container-scatterplot">
+              <Scatterplot
+                setShowObs={setShowObs}
+                setShowVars={setShowVars}
+                isFullscreen={false}
+              />
+            </div>
+            <OffcanvasObs
+              show={showObs}
+              handleClose={() => setShowObs(false)}
             />
-          </div>
-          <OffcanvasObs show={showObs} handleClose={() => setShowObs(false)} />
-          <OffcanvasVars
-            show={showVars}
-            handleClose={() => setShowVars(false)}
-            mode={SELECTION_MODES.SINGLE}
-          />
-          <OffcanvasControls
-            show={showControls}
-            handleClose={() => setShowControls(false)}
-            Controls={ScatterplotControls}
-          />
-        </DatasetProvider>
-      </div>
-    </Container>
+            <OffcanvasVars
+              show={showVars}
+              handleClose={() => setShowVars(false)}
+              mode={SELECTION_MODES.SINGLE}
+            />
+            <OffcanvasControls
+              show={showControls}
+              handleClose={() => setShowControls(false)}
+              Controls={ScatterplotControls}
+            />
+          </DatasetProvider>
+        </div>
+      </Container>
+    </div>
   );
 }

--- a/sites/demo/src/containers/ViolinDemo.js
+++ b/sites/demo/src/containers/ViolinDemo.js
@@ -17,33 +17,35 @@ export default function ViolinDemo(props) {
   const [showControls, setShowControls] = useState(false);
 
   return (
-    <Container>
-      <div className="cherita-container">
-        <DatasetProvider {...props}>
-          <Toolbar
-            setShowObs={setShowObs}
-            setShowVars={setShowVars}
-            setShowControls={setShowControls}
-          />
-          <div className="cherita-container-plot">
-            <Violin />
-          </div>
-          <OffcanvasObs
-            show={showObs}
-            handleClose={() => setShowObs(false)}
-            showColor={false}
-          />
-          <OffcanvasVars
-            show={showVars}
-            handleClose={() => setShowVars(false)}
-          />
-          <OffcanvasControls
-            show={showControls}
-            handleClose={() => setShowControls(false)}
-            Controls={ViolinControls}
-          />
-        </DatasetProvider>
-      </div>
-    </Container>
+    <div className="h-100">
+      <Container>
+        <div className="cherita-container">
+          <DatasetProvider {...props}>
+            <Toolbar
+              setShowObs={setShowObs}
+              setShowVars={setShowVars}
+              setShowControls={setShowControls}
+            />
+            <div className="cherita-container-plot">
+              <Violin />
+            </div>
+            <OffcanvasObs
+              show={showObs}
+              handleClose={() => setShowObs(false)}
+              showColor={false}
+            />
+            <OffcanvasVars
+              show={showVars}
+              handleClose={() => setShowVars(false)}
+            />
+            <OffcanvasControls
+              show={showControls}
+              handleClose={() => setShowControls(false)}
+              Controls={ViolinControls}
+            />
+          </DatasetProvider>
+        </div>
+      </Container>
+    </div>
   );
 }

--- a/src/lib/components/full-page/FullPage.js
+++ b/src/lib/components/full-page/FullPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import { useMediaQuery } from "@mui/material";
 import { Card, Container, Modal } from "react-bootstrap";
@@ -39,9 +39,6 @@ export function FullPage({
   defaultPlotType = PLOT_TYPES.SCATTERPLOT,
   ...props
 }) {
-  const appRef = useRef();
-  const [appDimensions, setAppDimensions] = useState({ width: 0, height: 0 });
-
   const [showObs, setShowObs] = useState(false);
   const [showObsm, setShowObsm] = useState(false);
   const [showVars, setShowVars] = useState(false);
@@ -62,29 +59,6 @@ export function FullPage({
   const XlBreakpoint = useMediaQuery(BREAKPOINTS.XL);
   const showObsBtn = LgBreakpoint;
   const showVarsBtn = XlBreakpoint;
-
-  useEffect(() => {
-    const updateDimensions = () => {
-      if (appRef.current) {
-        // Get the distance from the top of the page to the target element
-        const rect = appRef.current.getBoundingClientRect();
-        const distanceFromTop = rect.top + window.scrollY;
-
-        // Calculate the available height for the Cherita app
-        const availableHeight = window.innerHeight - distanceFromTop;
-
-        // Update the dimensions to fit the viewport minus the navbar height
-        setAppDimensions({
-          width: appRef.current.offsetWidth,
-          height: availableHeight,
-        });
-      }
-    };
-
-    window.addEventListener("resize", updateDimensions);
-    updateDimensions();
-    return () => window.removeEventListener("resize", updateDimensions);
-  }, []);
 
   const { plotControls, varMode, showSelectedAsActive } = {
     [PLOT_TYPES.SCATTERPLOT]: {
@@ -140,17 +114,9 @@ export function FullPage({
   }, [plotType, showObsBtn, showVarsBtn]);
 
   return (
-    <div
-      ref={appRef}
-      className="cherita-app"
-      style={{ height: appDimensions.height }}
-    >
+    <div className="cherita-app">
       <DatasetProvider {...props}>
-        <Container
-          fluid
-          className="cherita-app-container"
-          style={{ height: appDimensions.height }}
-        >
+        <Container fluid className="cherita-app-container">
           <div className="cherita-app-obs modern-scrollbars border-end h-100">
             <ObsColsList
               {...props}

--- a/src/lib/components/scatterplot/Scatterplot.js
+++ b/src/lib/components/scatterplot/Scatterplot.js
@@ -158,7 +158,6 @@ export function Scatterplot({
       });
     }
   }, [
-    settings.selectedObsm,
     getRadiusScale,
     obsmData.data,
     obsmData.isPending,

--- a/src/lib/components/violin/Violin.js
+++ b/src/lib/components/violin/Violin.js
@@ -166,37 +166,46 @@ export function Violin({
   if (!serverError) {
     if (hasSelections) {
       return (
-        <div className="cherita-plot cherita-violin position-relative">
+        <div className="cherita-plot cherita-violin">
           {isPending && <LoadingSpinner />}
-          <Plot
-            data={data}
-            layout={layout}
-            useResizeHandler={true}
-            style={{ width: "100%", height: "100%" }}
-            config={{
-              displaylogo: false,
-              modeBarButtons: modeBarButtons,
-            }}
-          />
-          {fetchedData?.resampled && (
-            <Alert variant="warning">
-              <b>Warning:</b> For performance reasons this plot was generated
-              with resampled data. It will not be exactly the same as one
-              produced with the entire dataset. &nbsp;
-              <OverlayTrigger
-                placement="top"
-                overlay={
-                  <Tooltip>
-                    Resampled to 100K values following a Monte Carlo style
-                    approach to help ensure resampled data is a good
-                    representation of the original dataset's distribution.
-                  </Tooltip>
-                }
-              >
-                <FontAwesomeIcon icon={faCircleInfo}></FontAwesomeIcon>
-              </OverlayTrigger>
-            </Alert>
-          )}
+          <div className="d-flex flex-column h-100">
+            <div
+              className="flex-grow-1 position-relative"
+              style={{ minHeight: "0" }}
+            >
+              <Plot
+                data={data}
+                layout={layout}
+                useResizeHandler={true}
+                style={{ width: "100%", height: "100%" }}
+                config={{
+                  displaylogo: false,
+                  modeBarButtons: modeBarButtons,
+                }}
+              />
+            </div>
+            {fetchedData?.resampled && (
+              <div className="flex-shrink-0">
+                <Alert variant="warning" className="mb-1">
+                  <b>Warning:</b> For performance reasons this plot was
+                  generated with resampled data. It will not be exactly the same
+                  as one produced with the entire dataset. &nbsp;
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={
+                      <Tooltip>
+                        Resampled to 100K values following a Monte Carlo style
+                        approach to help ensure resampled data is a good
+                        representation of the original dataset's distribution.
+                      </Tooltip>
+                    }
+                  >
+                    <FontAwesomeIcon icon={faCircleInfo}></FontAwesomeIcon>
+                  </OverlayTrigger>
+                </Alert>
+              </div>
+            )}
+          </div>
         </div>
       );
     }

--- a/src/scss/components/layouts.scss
+++ b/src/scss/components/layouts.scss
@@ -128,6 +128,7 @@
 
 .cherita-app-canvas {
   .cherita-plot {
+    position: relative;
     height: 100%;
     min-height: 400px;
   }

--- a/src/scss/components/layouts.scss
+++ b/src/scss/components/layouts.scss
@@ -1,6 +1,8 @@
 .cherita-app {
-  position: relative;
-  width: 100%;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
 }
 
 .cherita-app {


### PR DESCRIPTION
- set cherita-app css style as flex column to make responsive
to remove useEffect with updateDimensions in FullPage, which could cause issues with the app size being updated with re-renders using outdated value

- fix violin plot layout so alert is displayed correctly under plot, sharing the parent height

- set 100% height to demos

Fixes #146