### PR TITLE
replace assign with defaultsDeep in settings context initializer

### DIFF
--- a/src/lib/context/SettingsContext.js
+++ b/src/lib/context/SettingsContext.js
@@ -109,8 +109,8 @@ const initializer = ({
   localSettings,
 }) => {
   const mergedSettings = canOverrideSettings
-    ? _.assign({}, initialSettings, defaultSettings, localSettings)
-    : _.assign({}, initialSettings, defaultSettings);
+    ? _.defaultsDeep({}, localSettings, defaultSettings, initialSettings)
+    : _.defaultsDeep({}, defaultSettings, initialSettings);
   return validateSettings(mergedSettings);
 };
 


### PR DESCRIPTION
to fix issues with nested objects getting overwritten by subsequent sources
e.g. defaultSettings defining not all params in a nested settings object would overwrite the nested object from the initialSettings, removing the params not defined in the defaultSettings