### PR TITLE
Refactor settings context to split data

### DIFF
--- a/src/lib/components/dotplot/Dotplot.js
+++ b/src/lib/components/dotplot/Dotplot.js
@@ -13,6 +13,7 @@ import {
 } from "../../context/SettingsContext";
 import { LoadingSpinner } from "../../utils/LoadingIndicators";
 import { useDebouncedFetch } from "../../utils/requests";
+import { useSelectedMultiVar, useSelectedObs } from "../../utils/Resolver";
 import {
   ControlsPlotlyToolbar,
   ObsPlotlyToolbar,
@@ -36,16 +37,17 @@ export function Dotplot({
   const [data, setData] = useState([]);
   const [layout, setLayout] = useState({});
   const [hasSelections, setHasSelections] = useState(false);
+
+  const selectedObs = useSelectedObs();
+  const selectedMultiVar = useSelectedMultiVar();
+
   const [params, setParams] = useState({
     url: dataset.url,
-    obsCol: settings.selectedObs,
-    obsValues: !settings.selectedObs?.omit.length
+    obsCol: selectedObs,
+    obsValues: !selectedObs?.omit.length
       ? null
-      : _.difference(
-          _.values(settings.selectedObs?.codes),
-          settings.selectedObs?.omit
-        ).map((c) => settings.selectedObs?.codesMap[c]),
-    varKeys: settings.selectedMultiVar.map((i) =>
+      : _.difference(selectedObs?.values, selectedObs?.omit),
+    varKeys: selectedMultiVar.map((i) =>
       i.isSet ? { name: i.name, indices: i.vars.map((v) => v.index) } : i.index
     ),
     obsIndices: isSliced ? [...(obsIndices || [])] : null,
@@ -57,7 +59,7 @@ export function Dotplot({
   // @TODO: set default scale
 
   useEffect(() => {
-    if (settings.selectedObs && settings.selectedMultiVar.length) {
+    if (selectedObs && selectedMultiVar.length) {
       setHasSelections(true);
     } else {
       setHasSelections(false);
@@ -66,14 +68,11 @@ export function Dotplot({
       return {
         ...p,
         url: dataset.url,
-        obsCol: settings.selectedObs,
-        obsValues: !settings.selectedObs?.omit.length
+        obsCol: selectedObs,
+        obsValues: !selectedObs?.omit.length
           ? null
-          : _.difference(
-              _.values(settings.selectedObs?.codes),
-              settings.selectedObs?.omit
-            ).map((c) => settings.selectedObs?.codesMap[c]),
-        varKeys: settings.selectedMultiVar.map((i) =>
+          : _.difference(selectedObs?.values, selectedObs?.omit),
+        varKeys: selectedMultiVar.map((i) =>
           i.isSet
             ? { name: i.name, indices: i.vars.map((v) => v.index) }
             : i.index
@@ -87,7 +86,7 @@ export function Dotplot({
     });
   }, [
     dataset.url,
-    settings.selectedObs,
+    selectedObs,
     settings.selectedMultiVar,
     settings.controls.scale.dotplot,
     settings.controls.meanOnlyExpressed,
@@ -95,6 +94,7 @@ export function Dotplot({
     dataset.varNamesCol,
     isSliced,
     obsIndices,
+    selectedMultiVar,
   ]);
 
   const updateColorscale = useCallback((colorscale) => {

--- a/src/lib/components/dotplot/Dotplot.js
+++ b/src/lib/components/dotplot/Dotplot.js
@@ -116,6 +116,7 @@ export function Dotplot({
     if (hasSelections && !isPending && !serverError) {
       setData(fetchedData.data);
       setLayout(fetchedData.layout);
+      // @TODO: keep colorAxis range from settings
       dispatch({
         type: "set.controls.colorAxis",
         colorAxis: {

--- a/src/lib/components/dotplot/Dotplot.js
+++ b/src/lib/components/dotplot/Dotplot.js
@@ -87,7 +87,6 @@ export function Dotplot({
   }, [
     dataset.url,
     selectedObs,
-    settings.selectedMultiVar,
     settings.controls.scale.dotplot,
     settings.controls.meanOnlyExpressed,
     settings.controls.expressionCutoff,

--- a/src/lib/components/heatmap/Heatmap.js
+++ b/src/lib/components/heatmap/Heatmap.js
@@ -10,6 +10,7 @@ import { useFilteredData } from "../../context/FilterContext";
 import { useSettings } from "../../context/SettingsContext";
 import { LoadingSpinner } from "../../utils/LoadingIndicators";
 import { useDebouncedFetch } from "../../utils/requests";
+import { useSelectedMultiVar, useSelectedObs } from "../../utils/Resolver";
 import {
   ControlsPlotlyToolbar,
   ObsPlotlyToolbar,
@@ -32,16 +33,17 @@ export function Heatmap({
   const [data, setData] = useState([]);
   const [layout, setLayout] = useState({});
   const [hasSelections, setHasSelections] = useState(false);
+
+  const selectedObs = useSelectedObs();
+  const selectedMultiVar = useSelectedMultiVar();
+
   const [params, setParams] = useState({
     url: dataset.url,
-    obsCol: settings.selectedObs,
-    obsValues: !settings.selectedObs?.omit.length
+    obsCol: selectedObs,
+    obsValues: !selectedObs?.omit.length
       ? null
-      : _.difference(
-          _.values(settings.selectedObs?.codes),
-          settings.selectedObs?.omit
-        ).map((c) => settings.selectedObs?.codesMap[c]),
-    varKeys: settings.selectedMultiVar.map((i) =>
+      : _.difference(selectedObs?.values, selectedObs?.omit),
+    varKeys: selectedMultiVar.map((i) =>
       i.isSet ? { name: i.name, indices: i.vars.map((v) => v.index) } : i.index
     ),
     obsIndices: isSliced ? [...(obsIndices || [])] : null,
@@ -49,7 +51,7 @@ export function Heatmap({
   });
 
   useEffect(() => {
-    if (settings.selectedObs && settings.selectedMultiVar.length) {
+    if (selectedObs && selectedMultiVar.length) {
       setHasSelections(true);
     } else {
       setHasSelections(false);
@@ -58,14 +60,11 @@ export function Heatmap({
       return {
         ...p,
         url: dataset.url,
-        obsCol: settings.selectedObs,
-        obsValues: !settings.selectedObs?.omit.length
+        obsCol: selectedObs,
+        obsValues: !selectedObs?.omit.length
           ? null
-          : _.difference(
-              _.values(settings.selectedObs?.codes),
-              settings.selectedObs?.omit
-            ).map((c) => settings.selectedObs?.codesMap[c]),
-        varKeys: settings.selectedMultiVar.map((i) =>
+          : _.difference(selectedObs?.values, selectedObs?.omit),
+        varKeys: selectedMultiVar.map((i) =>
           i.isSet
             ? { name: i.name, indices: i.vars.map((v) => v.index) }
             : i.index
@@ -75,8 +74,8 @@ export function Heatmap({
       };
     });
   }, [
-    settings.selectedMultiVar,
-    settings.selectedObs,
+    selectedMultiVar,
+    selectedObs,
     dataset.url,
     dataset.varNamesCol,
     obsIndices,

--- a/src/lib/components/matrixplot/Matrixplot.js
+++ b/src/lib/components/matrixplot/Matrixplot.js
@@ -10,6 +10,7 @@ import { useFilteredData } from "../../context/FilterContext";
 import { useSettings } from "../../context/SettingsContext";
 import { LoadingSpinner } from "../../utils/LoadingIndicators";
 import { useDebouncedFetch } from "../../utils/requests";
+import { useSelectedMultiVar, useSelectedObs } from "../../utils/Resolver";
 import {
   ControlsPlotlyToolbar,
   ObsPlotlyToolbar,
@@ -32,16 +33,17 @@ export function Matrixplot({
   const [data, setData] = useState([]);
   const [layout, setLayout] = useState({});
   const [hasSelections, setHasSelections] = useState(false);
+
+  const selectedObs = useSelectedObs();
+  const selectedMultiVar = useSelectedMultiVar();
+
   const [params, setParams] = useState({
     url: dataset.url,
-    obsCol: settings.selectedObs,
-    obsValues: !settings.selectedObs?.omit.length
+    obsCol: selectedObs,
+    obsValues: !selectedObs?.omit.length
       ? null
-      : _.difference(
-          _.values(settings.selectedObs?.codes),
-          settings.selectedObs?.omit
-        ).map((c) => settings.selectedObs?.codesMap[c]),
-    varKeys: settings.selectedMultiVar.map((i) =>
+      : _.difference(selectedObs?.values, selectedObs?.omit),
+    varKeys: selectedMultiVar.map((i) =>
       i.isSet ? { name: i.name, indices: i.vars.map((v) => v.index) } : i.index
     ),
     obsIndices: isSliced ? [...(obsIndices || [])] : null,
@@ -50,7 +52,7 @@ export function Matrixplot({
   });
 
   useEffect(() => {
-    if (settings.selectedObs && settings.selectedMultiVar.length) {
+    if (selectedObs && selectedMultiVar.length) {
       setHasSelections(true);
     } else {
       setHasSelections(false);
@@ -59,14 +61,11 @@ export function Matrixplot({
       return {
         ...p,
         url: dataset.url,
-        obsCol: settings.selectedObs,
-        obsValues: !settings.selectedObs?.omit.length
+        obsCol: selectedObs,
+        obsValues: !selectedObs?.omit.length
           ? null
-          : _.difference(
-              _.values(settings.selectedObs?.codes),
-              settings.selectedObs?.omit
-            ).map((c) => settings.selectedObs?.codesMap[c]),
-        varKeys: settings.selectedMultiVar.map((i) =>
+          : _.difference(selectedObs?.values, selectedObs?.omit),
+        varKeys: selectedMultiVar.map((i) =>
           i.isSet
             ? { name: i.name, indices: i.vars.map((v) => v.index) }
             : i.index
@@ -78,8 +77,8 @@ export function Matrixplot({
     });
   }, [
     settings.controls.scale.matrixplot,
-    settings.selectedMultiVar,
-    settings.selectedObs,
+    selectedMultiVar,
+    selectedObs,
     dataset.url,
     dataset.varNamesCol,
     obsIndices,

--- a/src/lib/components/obs-list/ObsItem.js
+++ b/src/lib/components/obs-list/ObsItem.js
@@ -14,6 +14,7 @@ import { useColor } from "../../helpers/color-helper";
 import { Histogram } from "../../utils/Histogram";
 import { LoadingLinear } from "../../utils/LoadingIndicators";
 import { useFetch } from "../../utils/requests";
+import { useSelectedVar } from "../../utils/Resolver";
 import { formatNumerical, FORMATS } from "../../utils/string";
 import { VirtualizedList } from "../../utils/VirtualizedList";
 import { useObsData } from "../../utils/zarrData";
@@ -50,15 +51,18 @@ const useObsHistogram = (obs, { enabled = true }) => {
   const dataset = useDataset();
   const settings = useSettings();
   const { obsIndices, isSliced } = useFilteredData();
+
+  const selectedVar = useSelectedVar();
+
   const [params, setParams] = useState({
     url: dataset.url,
     obsCol: _.omit(obs, "omit"), // avoid re-rendering when toggling unselected obs
-    varKey: settings.selectedVar?.isSet
+    varKey: selectedVar?.isSet
       ? {
-          name: settings.selectedVar?.name,
-          indices: settings.selectedVar?.vars.map((v) => v.index),
+          name: selectedVar?.name,
+          indices: selectedVar?.vars.map((v) => v.index),
         }
-      : settings.selectedVar?.index,
+      : selectedVar?.index,
     obsIndices: isSliced ? [...(obsIndices || [])] : null,
   });
 
@@ -67,20 +71,20 @@ const useObsHistogram = (obs, { enabled = true }) => {
       return {
         ...p,
         obsCol: _.omit(obs, "omit"),
-        varKey: settings.selectedVar?.isSet
+        varKey: selectedVar?.isSet
           ? {
-              name: settings.selectedVar?.name,
-              indices: settings.selectedVar?.vars.map((v) => v.index),
+              name: selectedVar?.name,
+              indices: selectedVar?.vars.map((v) => v.index),
             }
-          : settings.selectedVar?.index,
+          : selectedVar?.index,
         obsIndices: isSliced ? [...(obsIndices || [])] : null,
       };
     });
   }, [
-    settings.selectedVar?.index,
-    settings.selectedVar?.isSet,
-    settings.selectedVar?.name,
-    settings.selectedVar?.vars,
+    selectedVar?.index,
+    selectedVar?.isSet,
+    selectedVar?.name,
+    selectedVar?.vars,
     obsIndices,
     isSliced,
     obs,
@@ -89,7 +93,7 @@ const useObsHistogram = (obs, { enabled = true }) => {
   return useFetch(ENDPOINT, params, {
     enabled:
       enabled &&
-      !!settings.selectedVar &&
+      !!selectedVar &&
       settings.colorEncoding === COLOR_ENCODINGS.VAR,
     refetchOnMount: false,
   });

--- a/src/lib/components/obs-list/ObsItem.js
+++ b/src/lib/components/obs-list/ObsItem.js
@@ -303,7 +303,7 @@ export function CategoricalObs({
           value_counts: obs.value_counts[obs.values[index]],
           pct: (obs.value_counts[obs.values[index]] / totalCounts) * 100,
         },
-        isOmitted: _.includes(obs.omit, obs.codes[obs.values[index]]),
+        isOmitted: _.includes(obs.omit, obs.values[index]),
         label: obs.values[index],
         histogramData:
           showHistograms && settings.colorEncoding === COLOR_ENCODINGS.VAR
@@ -445,7 +445,7 @@ export function ContinuousObs({
           value_counts: obs.value_counts[obs.values[index]],
           pct: (obs.value_counts[obs.values[index]] / totalCounts) * 100,
         },
-        isOmitted: _.includes(obs.omit, obs.codes[obs.values[index]]),
+        isOmitted: _.includes(obs.omit, obs.values[index]),
         label: isNaN(obs.values[index])
           ? "NaN"
           : getContinuousLabel(obs.codes[obs.values[index]], obs.bins.binEdges),

--- a/src/lib/components/obs-list/ObsList.js
+++ b/src/lib/components/obs-list/ObsList.js
@@ -111,13 +111,24 @@ export function ObsColsList({
       setObsCols(
         _.keyBy(
           _.map(filteredData, (d) => {
-            return { ...d, codesMap: _.invert(d.codes), omit: [] };
+            if (settings.selectedObs?.name === d.name) {
+              return { ...d, omit: settings.selectedObs.omit || [] };
+            }
+            return { ...d, omit: [] };
           }),
           "name"
         )
       );
     }
-  }, [fetchedData, isPending, obsGroups, serverError, enableGroups]);
+  }, [
+    fetchedData,
+    isPending,
+    obsGroups,
+    serverError,
+    enableGroups,
+    settings.selectedObs?.name,
+    settings.selectedObs?.omit,
+  ]);
 
   useEffect(() => {
     if (obsCols) {
@@ -147,13 +158,13 @@ export function ObsColsList({
   };
 
   const toggleLabel = (item) => {
-    const inLabelObs = _.some(settings.labelObs, (i) => i.name === item.name);
+    const inLabelObs = _.includes(settings.labelObs, item.name);
     if (inLabelObs) {
       dispatch({ type: "remove.label.obs", obsName: item.name });
     } else {
       dispatch({
         type: "add.label.obs",
-        obs: { name: item.name, type: item.type, codesMap: item.codesMap },
+        obs: item,
       });
     }
   };
@@ -189,7 +200,7 @@ export function ObsColsList({
     if (item.type === OBS_TYPES.DISCRETE) {
       return null;
     }
-    const inLabelObs = _.some(settings.labelObs, (i) => i.name === item.name);
+    const inLabelObs = _.includes(settings.labelObs, item.name);
     const inSliceObs =
       settings.sliceBy.obs && settings.selectedObs?.name === item.name;
     const isColorEncoding =

--- a/src/lib/components/obs-list/ObsList.js
+++ b/src/lib/components/obs-list/ObsList.js
@@ -137,9 +137,7 @@ export function ObsColsList({
   };
 
   const toggleAll = (item) => {
-    const omit = item.omit.length
-      ? []
-      : _.map(item.values, (v) => item.codes[v]);
+    const omit = item.omit.length ? [] : item.values;
     setObsCols((o) => {
       return { ...o, [item.name]: { ...item, omit: omit } };
     });
@@ -171,10 +169,10 @@ export function ObsColsList({
 
   const toggleObs = (item, value) => {
     let omit;
-    if (_.includes(item.omit, item.codes[value])) {
-      omit = item.omit.filter((i) => i !== item.codes[value]);
+    if (_.includes(item.omit, value)) {
+      omit = item.omit.filter((i) => i !== value);
     } else {
-      omit = [...item.omit, item.codes[value]];
+      omit = [...item.omit, value];
     }
     setObsCols((o) => {
       return { ...o, [item.name]: { ...item, omit: omit } };

--- a/src/lib/components/pseudospatial/Pseudospatial.js
+++ b/src/lib/components/pseudospatial/Pseudospatial.js
@@ -124,6 +124,7 @@ export function Pseudospatial({
   const [layout, setLayout] = useState({});
   const { getColor } = useColor();
   const colorscale = useRef(settings.controls.colorScale);
+  const { valueMin, valueMax } = useFilteredData();
 
   const selectedObs = useSelectedObs();
 
@@ -185,16 +186,8 @@ export function Pseudospatial({
   useEffect(() => {
     if (sharedScaleRange) {
       const { min, max } = {
-        min:
-          settings.controls.range[0] *
-            (settings.controls.valueRange[1] -
-              settings.controls.valueRange[0]) +
-          settings.controls.valueRange[0],
-        max:
-          settings.controls.range[1] *
-            (settings.controls.valueRange[1] -
-              settings.controls.valueRange[0]) +
-          settings.controls.valueRange[0],
+        min: settings.controls.range[0] * (valueMax - valueMin) + valueMin,
+        max: settings.controls.range[1] * (valueMax - valueMin) + valueMin,
       };
 
       setData((d) => {
@@ -220,9 +213,10 @@ export function Pseudospatial({
     settings.controls.range,
     settings.controls.valueMax,
     settings.controls.valueMin,
-    settings.controls.valueRange,
     getColor,
     sharedScaleRange,
+    valueMax,
+    valueMin,
   ]);
 
   const hasSelections = !!plotType && !!settings.pseudospatial.maskSet;

--- a/src/lib/components/scatterplot/Scatterplot.js
+++ b/src/lib/components/scatterplot/Scatterplot.js
@@ -37,6 +37,7 @@ import { Legend } from "../../utils/Legend";
 import { LoadingLinear, LoadingSpinner } from "../../utils/LoadingIndicators";
 import { formatNumerical } from "../../utils/string";
 import { useLabelObsData } from "../../utils/zarrData";
+import { useSelectedObs } from "../../utils/Resolver";
 
 window.deck.log.level = 1;
 
@@ -71,12 +72,7 @@ export function Scatterplot({
   });
   const [coordsError, setCoordsError] = useState(null);
 
-  const selectedObs = useMemo(() => {
-    if (settings.selectedObs) {
-      return settings.data.obs[settings.selectedObs.name];
-    }
-    return null;
-  }, [settings.data.obs, settings.selectedObs]);
+  const selectedObs = useSelectedObs();
 
   // EditableGeoJsonLayer
   const [mode, setMode] = useState(() => ViewMode);
@@ -403,7 +399,7 @@ export function Scatterplot({
     if (
       settings.colorEncoding === COLOR_ENCODINGS.OBS &&
       selectedObs &&
-      !_.some(settings.labelObs, { name: selectedObs.name })
+      !_.includes(settings.labelObs, selectedObs.name)
     ) {
       text.push(getLabel(selectedObs, data.values?.[getOriginalIndex(index)]));
     }
@@ -424,7 +420,7 @@ export function Scatterplot({
     if (settings.labelObs.length) {
       text.push(
         ..._.map(labelObsData.data, (v, k) => {
-          const labelObs = _.find(settings.labelObs, (o) => o.name === k);
+          const labelObs = settings.data.obs[k];
           return getLabel(labelObs, v[getOriginalIndex(index)]);
         })
       );

--- a/src/lib/components/scatterplot/Scatterplot.js
+++ b/src/lib/components/scatterplot/Scatterplot.js
@@ -241,13 +241,6 @@ export function Scatterplot({
     }
   }, [settings.colorEncoding, selectedObs?.type]);
 
-  useEffect(() => {
-    dispatch({
-      type: "set.controls.valueRange",
-      valueRange: [valueMin, valueMax],
-    });
-  }, [dispatch, valueMax, valueMin]);
-
   const { min, max } = {
     min: settings.controls.range[0] * (valueMax - valueMin) + valueMin,
     max: settings.controls.range[1] * (valueMax - valueMin) + valueMin,

--- a/src/lib/components/scatterplot/Scatterplot.js
+++ b/src/lib/components/scatterplot/Scatterplot.js
@@ -71,6 +71,13 @@ export function Scatterplot({
   });
   const [coordsError, setCoordsError] = useState(null);
 
+  const selectedObs = useMemo(() => {
+    if (settings.selectedObs) {
+      return settings.data.obs[settings.selectedObs.name];
+    }
+    return null;
+  }, [settings.data.obs, settings.selectedObs]);
+
   // EditableGeoJsonLayer
   const [mode, setMode] = useState(() => ViewMode);
   const [features, setFeatures] = useState({
@@ -186,7 +193,7 @@ export function Scatterplot({
     if (
       (settings.colorEncoding === COLOR_ENCODINGS.VAR ||
         (settings.colorEncoding === COLOR_ENCODINGS.OBS &&
-          settings.selectedObs?.type === OBS_TYPES.CONTINUOUS)) &&
+          selectedObs?.type === OBS_TYPES.CONTINUOUS)) &&
       data.positions &&
       data.values &&
       data.positions.length === data.values.length
@@ -217,8 +224,8 @@ export function Scatterplot({
     data,
     identityGetOriginalIndex,
     identitySortedIndexMap,
+    selectedObs?.type,
     settings.colorEncoding,
-    settings.selectedObs?.type,
   ]);
 
   const sortedObsIndices = useMemo(() => {
@@ -230,13 +237,13 @@ export function Scatterplot({
   const isCategorical = useMemo(() => {
     if (settings.colorEncoding === COLOR_ENCODINGS.OBS) {
       return (
-        settings.selectedObs?.type === OBS_TYPES.CATEGORICAL ||
-        settings.selectedObs?.type === OBS_TYPES.BOOLEAN
+        selectedObs?.type === OBS_TYPES.CATEGORICAL ||
+        selectedObs?.type === OBS_TYPES.BOOLEAN
       );
     } else {
       return false;
     }
-  }, [settings.colorEncoding, settings.selectedObs?.type]);
+  }, [settings.colorEncoding, selectedObs?.type]);
 
   useEffect(() => {
     dispatch({
@@ -261,8 +268,8 @@ export function Scatterplot({
           grayOut: grayOut,
           ...(useUnsColors &&
           settings.colorEncoding === COLOR_ENCODINGS.OBS &&
-          settings.selectedObs?.colors
-            ? { colorscale: settings.selectedObs?.colors }
+          selectedObs?.colors
+            ? { colorscale: selectedObs?.colors }
             : {}),
         }) || [0, 0, 0, 100]
       );
@@ -277,7 +284,7 @@ export function Scatterplot({
       isCategorical,
       useUnsColors,
       settings.colorEncoding,
-      settings.selectedObs?.colors,
+      selectedObs?.colors,
     ]
   );
 
@@ -395,12 +402,10 @@ export function Scatterplot({
 
     if (
       settings.colorEncoding === COLOR_ENCODINGS.OBS &&
-      settings.selectedObs &&
-      !_.some(settings.labelObs, { name: settings.selectedObs.name })
+      selectedObs &&
+      !_.some(settings.labelObs, { name: selectedObs.name })
     ) {
-      text.push(
-        getLabel(settings.selectedObs, data.values?.[getOriginalIndex(index)])
-      );
+      text.push(getLabel(selectedObs, data.values?.[getOriginalIndex(index)]));
     }
 
     if (
@@ -496,7 +501,7 @@ export function Scatterplot({
                 settings.colorEncoding === COLOR_ENCODINGS.VAR
                   ? settings.selectedVar?.name
                   : settings.colorEncoding === COLOR_ENCODINGS.OBS
-                    ? settings.selectedObs?.name
+                    ? selectedObs?.name
                     : null
               }
               obsLength={parseInt(data.positions?.length)}

--- a/src/lib/components/scatterplot/Scatterplot.js
+++ b/src/lib/components/scatterplot/Scatterplot.js
@@ -35,9 +35,9 @@ import { rgbToHex, useColor } from "../../helpers/color-helper";
 import { MapHelper } from "../../helpers/map-helper";
 import { Legend } from "../../utils/Legend";
 import { LoadingLinear, LoadingSpinner } from "../../utils/LoadingIndicators";
+import { useSelectedObs } from "../../utils/Resolver";
 import { formatNumerical } from "../../utils/string";
 import { useLabelObsData } from "../../utils/zarrData";
-import { useSelectedObs } from "../../utils/Resolver";
 
 window.deck.log.level = 1;
 

--- a/src/lib/components/scatterplot/ScatterplotControls.js
+++ b/src/lib/components/scatterplot/ScatterplotControls.js
@@ -4,6 +4,7 @@ import { Box, Slider, Typography } from "@mui/material";
 import { Form } from "react-bootstrap";
 
 import { COLOR_ENCODINGS, OBS_TYPES } from "../../constants/constants";
+import { useFilteredData } from "../../context/FilterContext";
 import {
   useSettings,
   useSettingsDispatch,
@@ -17,6 +18,7 @@ export const ScatterplotControls = () => {
   const [sliderValue, setSliderValue] = React.useState(
     settings.controls.range || [0, 1]
   );
+  const { valueMin, valueMax } = useFilteredData();
 
   const selectedObs = useSelectedObs();
 
@@ -26,11 +28,7 @@ export const ScatterplotControls = () => {
       : false;
 
   const valueLabelFormat = (value) => {
-    return (
-      value *
-        (settings.controls.valueRange[1] - settings.controls.valueRange[0]) +
-      settings.controls.valueRange[0]
-    ).toFixed(2);
+    return (value * (valueMax - valueMin) + valueMin).toFixed(2);
   };
 
   const marks = [

--- a/src/lib/components/scatterplot/ScatterplotControls.js
+++ b/src/lib/components/scatterplot/ScatterplotControls.js
@@ -8,6 +8,7 @@ import {
   useSettings,
   useSettingsDispatch,
 } from "../../context/SettingsContext";
+import { useSelectedObs } from "../../utils/Resolver";
 import { ColorscaleSelect } from "../controls/Controls";
 
 export const ScatterplotControls = () => {
@@ -17,9 +18,11 @@ export const ScatterplotControls = () => {
     settings.controls.range || [0, 1]
   );
 
+  const selectedObs = useSelectedObs();
+
   const isCategorical =
     settings.colorEncoding === COLOR_ENCODINGS.OBS
-      ? settings.selectedObs?.type === OBS_TYPES.CATEGORICAL
+      ? selectedObs?.type === OBS_TYPES.CATEGORICAL
       : false;
 
   const valueLabelFormat = (value) => {

--- a/src/lib/components/var-list/VarList.js
+++ b/src/lib/components/var-list/VarList.js
@@ -18,6 +18,11 @@ import {
 } from "../../context/SettingsContext";
 import { LoadingSpinner } from "../../utils/LoadingIndicators";
 import { useFetch } from "../../utils/requests";
+import {
+  useSelectedMultiVar,
+  useSelectedVar,
+  useSettingsVars,
+} from "../../utils/Resolver";
 
 export const useVarMean = (varKeys, enabled = false) => {
   const ENDPOINT = "matrix/mean";
@@ -26,7 +31,9 @@ export const useVarMean = (varKeys, enabled = false) => {
   const [params, setParams] = useState({
     url: dataset.url,
     varKeys: _.map(varKeys, (v) =>
-      v.isSet ? { name: v.name, indices: v.vars.map((v) => v.index) } : v.index
+      v.isSet
+        ? { name: v.name, indices: v.vars.map((vv) => vv.index) }
+        : v.index
     ),
     obsIndices: obsIndices,
     varNamesCol: dataset.varNamesCol,
@@ -38,7 +45,7 @@ export const useVarMean = (varKeys, enabled = false) => {
         ...p,
         varKeys: _.map(varKeys, (v) =>
           v.isSet
-            ? { name: v.name, indices: v.vars.map((v) => v.index) }
+            ? { name: v.name, indices: v.vars.map((vv) => vv.index) }
             : v.index
         ),
         obsIndices: obsIndices,
@@ -63,29 +70,32 @@ export function VarNamesList({
 }) {
   const settings = useSettings();
   const dispatch = useSettingsDispatch();
+
+  const selectedVar = useSelectedVar();
+  const selectedMultiVar = useSelectedMultiVar();
+  const settingsVars = useSettingsVars();
+
   const [active, setActive] = useState(
     mode === SELECTION_MODES.SINGLE
-      ? settings.selectedVar?.matrix_index || settings.selectedVar?.name
-      : settings.selectedMultiVar.map((i) => i.matrix_index || i.name)
+      ? selectedVar?.matrix_index || selectedVar?.name
+      : selectedMultiVar.map((i) => i.matrix_index || i.name)
   );
   const [sortedVars, setSortedVars] = useState([]);
 
   useEffect(() => {
     if (mode === SELECTION_MODES.SINGLE) {
-      setActive(
-        settings.selectedVar?.matrix_index || settings.selectedVar?.name
-      );
+      setActive(selectedVar?.matrix_index || selectedVar?.name);
     }
-  }, [mode, settings.selectedVar]);
+  }, [mode, selectedVar]);
 
   useEffect(() => {
     if (mode === SELECTION_MODES.MULTIPLE) {
-      setActive(settings.selectedMultiVar.map((i) => i.matrix_index || i.name));
+      setActive(selectedMultiVar.map((i) => i.matrix_index || i.name));
     }
-  }, [mode, settings.selectedMultiVar]);
+  }, [mode, selectedMultiVar]);
 
   const varMeans = useVarMean(
-    settings.vars,
+    settingsVars,
     settings.varSort.var.sort === VAR_SORT.MATRIX
   );
 
@@ -99,7 +109,7 @@ export function VarNamesList({
       ) {
         setSortedVars(
           _.orderBy(
-            settings.vars,
+            settingsVars,
             (o) => {
               return sortMeans(o, varMeans.fetchedData);
             },
@@ -109,10 +119,10 @@ export function VarNamesList({
       }
     } else if (settings.varSort.var.sort === VAR_SORT.NAME) {
       setSortedVars(
-        _.orderBy(settings.vars, "name", settings.varSort.var.sortOrder)
+        _.orderBy(settingsVars, "name", settings.varSort.var.sortOrder)
       );
     } else {
-      setSortedVars(settings.vars);
+      setSortedVars(settingsVars);
     }
   }, [
     settings.varSort.var.sort,
@@ -120,7 +130,7 @@ export function VarNamesList({
     varMeans.isPending,
     varMeans.serverError,
     varMeans.fetchedData,
-    settings.vars,
+    settingsVars,
   ]);
 
   const makeListItem = (item) => {

--- a/src/lib/components/violin/Violin.js
+++ b/src/lib/components/violin/Violin.js
@@ -16,6 +16,11 @@ import { useSettings } from "../../context/SettingsContext";
 import { LoadingSpinner } from "../../utils/LoadingIndicators";
 import { useDebouncedFetch } from "../../utils/requests";
 import {
+  useSelectedMultiVar,
+  useSelectedObs,
+  useSelectedVar,
+} from "../../utils/Resolver";
+import {
   ControlsPlotlyToolbar,
   ObsPlotlyToolbar,
   VarPlotlyToolbar,
@@ -37,6 +42,11 @@ export function Violin({
   const [data, setData] = useState([]);
   const [layout, setLayout] = useState({});
   const [hasSelections, setHasSelections] = useState(false);
+
+  const selectedMultiVar = useSelectedMultiVar();
+  const selectedVar = useSelectedVar();
+  const selectedObs = useSelectedObs();
+
   const [params, setParams] = useState({
     url: dataset.url,
     mode: mode,
@@ -44,7 +54,7 @@ export function Violin({
     varNamesCol: dataset.varNamesCol,
     ...{
       [VIOLIN_MODES.MULTIKEY]: {
-        varKeys: settings.selectedMultiVar.map((i) =>
+        varKeys: selectedMultiVar.map((i) =>
           i.isSet
             ? { name: i.name, indices: i.vars.map((v) => v.index) }
             : i.index
@@ -52,19 +62,16 @@ export function Violin({
         obsKeys: [], // @TODO: implement
       },
       [VIOLIN_MODES.GROUPBY]: {
-        varKey: settings.selectedVar?.isSet
+        varKey: selectedVar?.isSet
           ? {
-              name: settings.selectedVar?.name,
-              indices: settings.selectedVar?.vars.map((v) => v.index),
+              name: selectedVar?.name,
+              indices: selectedVar?.vars.map((v) => v.index),
             }
-          : settings.selectedVar?.index,
-        obsCol: settings.selectedObs,
-        obsValues: !settings.selectedObs?.omit.length
+          : selectedVar?.index,
+        obsCol: selectedObs,
+        obsValues: !selectedObs?.omit.length
           ? null
-          : _.difference(
-              _.values(settings.selectedObs?.codes),
-              settings.selectedObs?.omit
-            ).map((c) => settings.selectedObs?.codesMap[c]),
+          : _.difference(selectedObs?.values, selectedObs?.omit),
         obsIndices: isSliced ? [...(obsIndices || [])] : null,
       },
     }[mode],
@@ -73,7 +80,7 @@ export function Violin({
 
   useEffect(() => {
     if (mode === VIOLIN_MODES.MULTIKEY) {
-      if (settings.selectedMultiVar.length) {
+      if (selectedMultiVar.length) {
         setHasSelections(true);
       } else {
         setHasSelections(false);
@@ -83,7 +90,7 @@ export function Violin({
           ...p,
           url: dataset.url,
           mode: mode,
-          varKeys: settings.selectedMultiVar.map((i) =>
+          varKeys: selectedMultiVar.map((i) =>
             i.isSet
               ? { name: i.name, indices: i.vars.map((v) => v.index) }
               : i.index
@@ -93,7 +100,7 @@ export function Violin({
         };
       });
     } else if (mode === VIOLIN_MODES.GROUPBY) {
-      if (settings.selectedObs && settings.selectedVar) {
+      if (selectedObs && selectedVar) {
         setHasSelections(true);
       } else {
         setHasSelections(false);
@@ -103,19 +110,16 @@ export function Violin({
           ...p,
           url: dataset.url,
           mode: mode,
-          varKey: settings.selectedVar?.isSet
+          varKey: selectedVar?.isSet
             ? {
-                name: settings.selectedVar?.name,
-                indices: settings.selectedVar?.vars.map((v) => v.index),
+                name: selectedVar?.name,
+                indices: selectedVar?.vars.map((v) => v.index),
               }
-            : settings.selectedVar?.index,
-          obsCol: settings.selectedObs,
-          obsValues: !settings.selectedObs?.omit.length
+            : selectedVar?.index,
+          obsCol: selectedObs,
+          obsValues: !selectedObs?.omit.length
             ? null
-            : _.difference(
-                _.values(settings.selectedObs?.codes),
-                settings.selectedObs?.omit
-              ).map((c) => settings.selectedObs?.codesMap[c]),
+            : _.difference(selectedObs?.values, selectedObs?.omit),
           obsIndices: isSliced ? [...(obsIndices || [])] : null,
           scale: settings.controls.scale.violinplot,
           varNamesCol: dataset.varNamesCol,
@@ -124,9 +128,9 @@ export function Violin({
     }
   }, [
     settings.controls.scale.violinplot,
-    settings.selectedMultiVar,
-    settings.selectedObs,
-    settings.selectedVar,
+    selectedMultiVar,
+    selectedObs,
+    selectedVar,
     dataset.url,
     dataset.varNamesCol,
     obsIndices,

--- a/src/lib/context/DatasetContext.js
+++ b/src/lib/context/DatasetContext.js
@@ -8,7 +8,6 @@ import _ from "lodash";
 import { FilterProvider } from "./FilterContext";
 import { SettingsProvider } from "./SettingsContext";
 import { ZarrDataProvider } from "./ZarrDataContext";
-import { DataProvider } from "../utils/Resolver";
 
 export const DatasetContext = createContext(null);
 
@@ -73,17 +72,15 @@ export function DatasetProvider({ dataset_url, children, ...dataset_params }) {
         client={queryClient}
         persistOptions={persistOptions}
       >
-        <DataProvider>
-          <SettingsProvider
-            dataset_url={dataset.url}
-            defaultSettings={dataset.defaultSettings}
-            canOverrideSettings={dataset.canOverrideSettings}
-          >
-            <FilterProvider>
-              <ZarrDataProvider>{children}</ZarrDataProvider>
-            </FilterProvider>
-          </SettingsProvider>
-        </DataProvider>
+        <SettingsProvider
+          dataset_url={dataset.url}
+          defaultSettings={dataset.defaultSettings}
+          canOverrideSettings={dataset.canOverrideSettings}
+        >
+          <FilterProvider>
+            <ZarrDataProvider>{children}</ZarrDataProvider>
+          </FilterProvider>
+        </SettingsProvider>
       </PersistQueryClientProvider>
     </DatasetContext.Provider>
   );

--- a/src/lib/context/DatasetContext.js
+++ b/src/lib/context/DatasetContext.js
@@ -8,6 +8,7 @@ import _ from "lodash";
 import { FilterProvider } from "./FilterContext";
 import { SettingsProvider } from "./SettingsContext";
 import { ZarrDataProvider } from "./ZarrDataContext";
+import { DataProvider } from "../utils/Resolver";
 
 export const DatasetContext = createContext(null);
 
@@ -68,20 +69,22 @@ export function DatasetProvider({ dataset_url, children, ...dataset_params }) {
 
   return (
     <DatasetContext.Provider value={dataset}>
-      <SettingsProvider
-        dataset_url={dataset.url}
-        defaultSettings={dataset.defaultSettings}
-        canOverrideSettings={dataset.canOverrideSettings}
+      <PersistQueryClientProvider
+        client={queryClient}
+        persistOptions={persistOptions}
       >
-        <PersistQueryClientProvider
-          client={queryClient}
-          persistOptions={persistOptions}
-        >
-          <FilterProvider>
-            <ZarrDataProvider>{children}</ZarrDataProvider>
-          </FilterProvider>
-        </PersistQueryClientProvider>
-      </SettingsProvider>
+        <DataProvider>
+          <SettingsProvider
+            dataset_url={dataset.url}
+            defaultSettings={dataset.defaultSettings}
+            canOverrideSettings={dataset.canOverrideSettings}
+          >
+            <FilterProvider>
+              <ZarrDataProvider>{children}</ZarrDataProvider>
+            </FilterProvider>
+          </SettingsProvider>
+        </DataProvider>
+      </PersistQueryClientProvider>
     </DatasetContext.Provider>
   );
 }

--- a/src/lib/context/SettingsContext.js
+++ b/src/lib/context/SettingsContext.js
@@ -177,8 +177,6 @@ export function SettingsProvider({
     validate
   );
 
-  // @TODO: remove items in data if not in any selection
-
   useEffect(() => {
     // If resolvedSettings is null, do not update settings
     if (resolvedSettings) {

--- a/src/lib/context/SettingsContext.js
+++ b/src/lib/context/SettingsContext.js
@@ -196,7 +196,7 @@ export function SettingsProvider({
           JSON.stringify({
             buster: process.env.PACKAGE_VERSION || "0.0.0",
             timestamp: Date.now(),
-            // ..._.omit(settings, "data"),
+            ..._.omit(settings, "data"),
             ...settings,
           })
         );

--- a/src/lib/context/SettingsContext.js
+++ b/src/lib/context/SettingsContext.js
@@ -109,8 +109,8 @@ const initializer = ({
   localSettings,
 }) => {
   const mergedSettings = canOverrideSettings
-    ? _.assign({}, initialSettings, defaultSettings, localSettings)
-    : _.assign({}, initialSettings, defaultSettings);
+    ? _.defaultsDeep({}, localSettings, defaultSettings, initialSettings)
+    : _.defaultsDeep({}, defaultSettings, initialSettings);
   return validateSettings(mergedSettings);
 };
 

--- a/src/lib/context/SettingsContext.js
+++ b/src/lib/context/SettingsContext.js
@@ -36,8 +36,7 @@ const initialSettings = {
   polygons: {},
   controls: {
     colorScale: "Viridis",
-    valueRange: [0, 1],
-    range: [0, 1],
+    range: [0, 1], // normalized
     colorAxis: { dmin: 0, dmax: 1, cmin: 0, cmax: 1 },
     scale: {
       dotplot: DOTPLOT_SCALES.NONE.value,
@@ -65,7 +64,6 @@ const initialSettings = {
     vars: {},
     controls: {
       // should just be settings?
-      valueRange: [0, 1], // depends on colorEncoding; `range` is slider value in settings
       colorAxis: { dmin: 0, dmax: 1, cmin: 0, cmax: 1 }, // cmin/cmax depend on selections
     },
   },
@@ -457,12 +455,6 @@ function settingsReducer(settings, action) {
       return {
         ...settings,
         controls: { ...settings.controls, colorScale: action.colorScale },
-      };
-    }
-    case "set.controls.valueRange": {
-      return {
-        ...settings,
-        controls: { ...settings.controls, valueRange: action.valueRange },
       };
     }
     case "set.controls.range": {

--- a/src/lib/context/SettingsContext.js
+++ b/src/lib/context/SettingsContext.js
@@ -111,6 +111,20 @@ const validateSettings = (settings) => {
 
   // @TODO: validate pseudospatial settings
 
+  // Keep only obs in use (selectedObs, labelObs) in data.obs
+  const obsNames = _.uniq(
+    _.compact([settings.selectedObs?.name, ...settings.labelObs])
+  );
+  const intersectionObs = _.intersection(_.keys(settings.data.obs), obsNames);
+  settings.data.obs = _.pick(settings.data.obs, intersectionObs);
+
+  // Keep only vars in use (settings.vars) in data.vars
+  const varNames = _.flatMap(settings.vars, (v) =>
+    v.isSet ? _.map(v.vars, (vv) => vv.name) : v.name
+  );
+  const intersectionVars = _.intersection(_.keys(settings.data.vars), varNames);
+  settings.data.vars = _.pick(settings.data.vars, intersectionVars);
+
   return settings;
 };
 
@@ -661,13 +675,13 @@ function settingsReducer(settings, action) {
       }
     }
     case "remove.label.obs": {
-      return {
+      return validateSettings({
         ...settings,
         labelObs: settings.labelObs.filter((a) => a !== action.obsName),
-      };
+      });
     }
     case "reset.label.obs": {
-      return { ...settings, labelObs: [] };
+      return validateSettings({ ...settings, labelObs: [] });
     }
     case "set.varSort": {
       return {

--- a/src/lib/context/SettingsContext.js
+++ b/src/lib/context/SettingsContext.js
@@ -663,7 +663,7 @@ function settingsReducer(settings, action) {
     case "remove.label.obs": {
       return {
         ...settings,
-        labelObs: settings.labelObs.filter((a) => a.name !== action.obsName),
+        labelObs: settings.labelObs.filter((a) => a !== action.obsName),
       };
     }
     case "reset.label.obs": {

--- a/src/lib/context/SettingsContext.js
+++ b/src/lib/context/SettingsContext.js
@@ -649,12 +649,12 @@ function settingsReducer(settings, action) {
         const { settings: obsSettings, data: obsData } = splitObs(action.obs);
         return {
           ...settings,
-          labelObs: [...settings.labelObs, obsSettings],
+          labelObs: [...settings.labelObs, obsSettings.name],
           data: {
             ...settings.data,
             obs: {
               ...settings.data.obs,
-              obsData,
+              ...obsData,
             },
           },
         };

--- a/src/lib/utils/Filter.js
+++ b/src/lib/utils/Filter.js
@@ -45,17 +45,24 @@ export const useFilter = (data) => {
   const settings = useSettings();
   const filterDataDispatch = useFilteredDataDispatch();
 
+  const selectedObs = useMemo(() => {
+    if (settings.selectedObs) {
+      return settings.data.obs[settings.selectedObs.name];
+    }
+    return null;
+  }, [settings.data.obs, settings.selectedObs]);
+
   const { obsmData, xData, obsData, isPending, serverError } = data;
 
   const isCategorical =
-    settings.selectedObs?.type === OBS_TYPES.CATEGORICAL ||
-    settings.selectedObs?.type === OBS_TYPES.BOOLEAN;
+    selectedObs?.type === OBS_TYPES.CATEGORICAL ||
+    selectedObs?.type === OBS_TYPES.BOOLEAN;
 
-  const isContinuous = settings.selectedObs?.type === OBS_TYPES.CONTINUOUS;
+  const isContinuous = selectedObs?.type === OBS_TYPES.CONTINUOUS;
 
   const sliceByObs =
     (settings.colorEncoding === COLOR_ENCODINGS.OBS &&
-      !!settings.selectedObs?.omit.length) ||
+      !!selectedObs?.omit.length) ||
     settings.sliceBy.obs;
 
   const isInObsSlice = useCallback(
@@ -64,15 +71,15 @@ export const useFilter = (data) => {
 
       if (values && sliceByObs) {
         if (isCategorical) {
-          inSlice &= isInValues(settings.selectedObs?.omit, values[index]);
+          inSlice &= isInValues(selectedObs?.omit, values[index]);
         } else if (isContinuous) {
           if (isNaN(values[index])) {
-            inSlice &= isInValues(settings.selectedObs?.omit, -1);
+            inSlice &= isInValues(selectedObs?.omit, -1);
           } else {
             inSlice &= isInBins(
               values[index],
-              settings.selectedObs.bins.binEdges,
-              _.without(settings.selectedObs.omit, -1)
+              selectedObs?.bins?.binEdges,
+              _.without(selectedObs.omit, -1)
             );
           }
         }
@@ -80,11 +87,11 @@ export const useFilter = (data) => {
       return inSlice;
     },
     [
-      settings.selectedObs?.bins?.binEdges,
-      settings.selectedObs?.omit,
+      sliceByObs,
       isCategorical,
       isContinuous,
-      sliceByObs,
+      selectedObs?.omit,
+      selectedObs?.bins?.binEdges,
     ]
   );
 

--- a/src/lib/utils/Resolver.js
+++ b/src/lib/utils/Resolver.js
@@ -1,0 +1,172 @@
+import { useState, useEffect, useMemo } from "react";
+
+import _ from "lodash";
+
+import { useFetch } from "./requests";
+import { useDataset } from "../context/DatasetContext";
+import { useSettings } from "../context/SettingsContext";
+
+export const useResolver = (initSettings) => {
+  const dataset = useDataset();
+
+  const [data, setData] = useState({
+    obs: {},
+    vars: {},
+  });
+  const [resolvedObs, setResolvedObs] = useState(false);
+  const [resolvedVars, setResolvedVars] = useState(false);
+
+  const [resolvedSettings, setResolvedSettings] = useState(null);
+
+  // obs
+  // all obs should be in initSettings.selectedObs and initSettings.labelObs
+  const initObs = _.compact([
+    initSettings.selectedObs,
+    ...initSettings.labelObs,
+  ]);
+  const initObsNames = _.map(initObs, (o) => o.name);
+  const [obsParams] = useState({
+    url: dataset.url,
+    cols: initObsNames,
+    obsParams: _.fromPairs(_.map(initObs, (o) => [o.name, { bins: o.bins }])),
+  });
+  const {
+    fetchedData: obsData,
+    isPending: obsDataPending,
+    serverError: obsDataError,
+  } = useFetch("obs/cols", obsParams, {
+    enabled: !!initObsNames.length,
+  });
+
+  // vars
+  // all vars should be in initSettings.vars from validation
+  const initVars = initSettings.vars;
+  const initVarsNames = _.flatMap(initVars, (v) =>
+    v.isSet ? _.map(v.vars, (vv) => vv.name) : v.name
+  );
+  const [varParams] = useState({
+    url: dataset.url,
+    col: dataset.varNamesCol,
+    names: initVarsNames,
+  });
+
+  const {
+    fetchedData: varData,
+    isPending: varDataPending,
+    serverError: varDataError,
+  } = useFetch("var/cols/names", varParams, {
+    enabled: !!varParams.names.length,
+  });
+
+  useEffect(() => {
+    if (!obsDataPending && !obsDataError) {
+      if (obsData) {
+        setData((d) => ({
+          ...d,
+          obs: _.fromPairs(_.map(obsData, (o) => [o.name, o])),
+        }));
+      }
+      setResolvedObs(true);
+    }
+  }, [obsData, obsDataError, obsDataPending, initSettings.selectedObs.omit]);
+
+  useEffect(() => {
+    if (!varDataPending && !varDataError) {
+      if (varData) {
+        setData((d) => ({
+          ...d,
+          vars: _.fromPairs(_.map(varData, (v) => [v.name, v])),
+        }));
+      }
+      setResolvedVars(true);
+    }
+  }, [initSettings.vars, varData, varDataError, varDataPending]);
+
+  // @TODO: remove from settings the obs and vars not in dataset (not in response)
+  useEffect(() => {
+    if (resolvedObs && resolvedVars) {
+      setResolvedSettings({
+        ...initSettings,
+        data: data,
+      });
+    }
+  }, [data, initSettings, resolvedObs, resolvedVars, setResolvedSettings]);
+
+  return resolvedSettings;
+};
+
+export const useSelectedObs = (obs = null) => {
+  const settings = useSettings();
+
+  return useMemo(() => {
+    return (
+      obs || {
+        ...settings.selectedObs,
+        ...settings.data.obs[settings.selectedObs?.name],
+      } ||
+      null
+    );
+  }, [obs, settings.data.obs, settings.selectedObs]);
+};
+
+export const useSelectedVar = (v = null) => {
+  const settings = useSettings();
+
+  return useMemo(() => {
+    return (
+      v || {
+        ...settings.selectedVar,
+        ...settings.data.vars[settings.selectedVar?.name],
+        vars: settings.selectedVar?.isSet
+          ? settings.selectedVar.vars.map((vv) => ({
+              ...settings.data.vars[vv.name],
+            }))
+          : [],
+      }
+    );
+  }, [settings.data.vars, settings.selectedVar, v]);
+};
+
+export const useSelectedMultiVar = () => {
+  const settings = useSettings();
+
+  return useMemo(() => {
+    return _.map(settings.selectedMultiVar, (v) => {
+      if (v.isSet) {
+        return {
+          ...v,
+          vars: v.vars.map((vv) => ({
+            ...settings.data.vars[vv.name],
+          })),
+        };
+      } else {
+        return {
+          ...v,
+          ...settings.data.vars[v.name],
+        };
+      }
+    });
+  }, [settings.data.vars, settings.selectedMultiVar]);
+};
+
+export const useSettingsVars = () => {
+  const settings = useSettings();
+
+  return useMemo(() => {
+    return _.map(settings.vars, (v) => {
+      if (v.isSet) {
+        return {
+          ...v,
+          vars: v.vars.map((vv) => ({
+            ...settings.data.vars[vv.name],
+          })),
+        };
+      } else {
+        return {
+          ...v,
+          ...settings.data.vars[v.name],
+        };
+      }
+    });
+  }, [settings.data.vars, settings.vars]);
+};

--- a/src/lib/utils/Resolver.js
+++ b/src/lib/utils/Resolver.js
@@ -120,7 +120,7 @@ export const useResolver = (initSettings) => {
       }
       setResolvedObs(true);
     }
-  }, [obsData, obsDataError, obsDataPending, initSettings.selectedObs.omit]);
+  }, [obsData, obsDataError, obsDataPending, initSettings.selectedObs?.omit]);
 
   useEffect(() => {
     if (!varDataPending) {

--- a/src/lib/utils/Resolver.js
+++ b/src/lib/utils/Resolver.js
@@ -67,15 +67,20 @@ export const useResolver = (initSettings) => {
 
   // obs
   // all obs should be in initSettings.selectedObs and initSettings.labelObs
-  const initObs = _.compact([
-    initSettings.selectedObs,
-    ...initSettings.labelObs,
-  ]);
+  const initObs = _.uniqBy(
+    _.compact([
+      initSettings.selectedObs,
+      ..._.map(initSettings.labelObs, (o) => ({ name: o })),
+    ]),
+    "name"
+  );
   const initObsNames = _.map(initObs, (o) => o.name);
   const [obsParams] = useState({
     url: dataset.url,
     cols: initObsNames,
-    obsParams: _.fromPairs(_.map(initObs, (o) => [o.name, { bins: o.bins }])),
+    obsParams: _.fromPairs(
+      _.map(initObs, (o) => [o.name, { bins: o.bins || {} }])
+    ),
   });
   const {
     fetchedData: obsData,

--- a/src/lib/utils/Resolver.js
+++ b/src/lib/utils/Resolver.js
@@ -95,26 +95,25 @@ export const useResolver = (initSettings) => {
   return resolvedSettings;
 };
 
-export const useSelectedObs = (obs = null) => {
+export const useSelectedObs = () => {
   const settings = useSettings();
 
   return useMemo(() => {
     return (
-      obs || {
+      {
         ...settings.selectedObs,
         ...settings.data.obs[settings.selectedObs?.name],
-      } ||
-      null
+      } || null
     );
-  }, [obs, settings.data.obs, settings.selectedObs]);
+  }, [settings.data.obs, settings.selectedObs]);
 };
 
-export const useSelectedVar = (v = null) => {
+export const useSelectedVar = () => {
   const settings = useSettings();
 
   return useMemo(() => {
     return (
-      v || {
+      {
         ...settings.selectedVar,
         ...settings.data.vars[settings.selectedVar?.name],
         vars: settings.selectedVar?.isSet
@@ -122,9 +121,9 @@ export const useSelectedVar = (v = null) => {
               ...settings.data.vars[vv.name],
             }))
           : [],
-      }
+      } || null
     );
-  }, [settings.data.vars, settings.selectedVar, v]);
+  }, [settings.data.vars, settings.selectedVar]);
 };
 
 export const useSelectedMultiVar = () => {

--- a/src/lib/utils/zarrData.js
+++ b/src/lib/utils/zarrData.js
@@ -89,21 +89,17 @@ export const useLabelObsData = () => {
 
   const labelObsParams = useMemo(
     () =>
-      _.compact(
-        _.map(settings.labelObs, (obsName) => {
-          const obs = settings.data.obs[obsName] || null;
-          return (
-            obs && {
-              url: dataset.url,
-              path:
-                "obs/" +
-                obs.name +
-                (obs.type === OBS_TYPES.CATEGORICAL ? "/codes" : ""),
-              key: obs.name,
-            }
-          );
-        })
-      ),
+      _.map(settings.labelObs, (obsName) => {
+        const obs = settings.data.obs[obsName] || null;
+        return {
+          url: dataset.url,
+          path:
+            "obs/" +
+            obs.name +
+            (obs.type === OBS_TYPES.CATEGORICAL ? "/codes" : ""),
+          key: obs.name,
+        };
+      }),
     [dataset.url, settings.data.obs, settings.labelObs]
   );
 

--- a/src/lib/utils/zarrData.js
+++ b/src/lib/utils/zarrData.js
@@ -65,7 +65,7 @@ export const useObsData = (obs = null) => {
   const dataset = useDataset();
   const settings = useSettings();
 
-  obs = obs || settings.selectedObs;
+  obs = obs || settings.data.obs[settings.selectedObs?.name] || null;
 
   const obsParams = useMemo(
     () => ({
@@ -88,6 +88,7 @@ export const useLabelObsData = () => {
   const labelObsParams = useMemo(
     () =>
       _.map(settings.labelObs, (obs) => {
+        obs = obs || settings.data.obs[obs.name] || null;
         return {
           url: dataset.url,
           path:
@@ -97,7 +98,7 @@ export const useLabelObsData = () => {
           key: obs.name,
         };
       }),
-    [dataset.url, settings.labelObs]
+    [dataset.url, settings.data.obs, settings.labelObs]
   );
 
   return useMultipleZarr(labelObsParams, GET_OPTIONS, {

--- a/src/lib/utils/zarrData.js
+++ b/src/lib/utils/zarrData.js
@@ -63,10 +63,11 @@ export const useXData = (agg = meanData) => {
   );
 };
 
-export const useObsData = (o = null) => {
+export const useObsData = (obs = null) => {
   const dataset = useDataset();
 
-  const obs = useSelectedObs(o);
+  const selectedObs = useSelectedObs();
+  obs = obs || selectedObs;
 
   const obsParams = useMemo(
     () => ({

--- a/src/lib/utils/zarrData.js
+++ b/src/lib/utils/zarrData.js
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import _ from "lodash";
 import { slice } from "zarr";
 
+import { useSelectedObs, useSelectedVar } from "./Resolver";
 import { OBS_TYPES } from "../constants/constants";
 import { useDataset } from "../context/DatasetContext";
 import { useSettings } from "../context/SettingsContext";
@@ -33,24 +34,25 @@ const meanData = (_i, data) => {
 
 export const useXData = (agg = meanData) => {
   const dataset = useDataset();
-  const settings = useSettings();
+
+  const selectedVar = useSelectedVar();
 
   const xParams = useMemo(
     () =>
-      !settings.selectedVar
+      !selectedVar
         ? []
-        : !settings.selectedVar?.isSet
+        : !selectedVar?.isSet
           ? [
               {
                 url: dataset.url,
                 path: "X",
-                s: [null, settings.selectedVar?.matrix_index],
+                s: [null, selectedVar?.matrix_index],
               },
             ]
-          : _.map(settings.selectedVar?.vars, (v) => {
+          : _.map(selectedVar?.vars, (v) => {
               return { url: dataset.url, path: "X", s: [null, v.matrix_index] };
             }),
-    [dataset.url, settings.selectedVar]
+    [dataset.url, selectedVar]
   );
 
   return useMultipleZarr(
@@ -61,11 +63,10 @@ export const useXData = (agg = meanData) => {
   );
 };
 
-export const useObsData = (obs = null) => {
+export const useObsData = (o = null) => {
   const dataset = useDataset();
-  const settings = useSettings();
 
-  obs = obs || settings.data.obs[settings.selectedObs?.name] || null;
+  const obs = useSelectedObs(o);
 
   const obsParams = useMemo(
     () => ({
@@ -87,17 +88,21 @@ export const useLabelObsData = () => {
 
   const labelObsParams = useMemo(
     () =>
-      _.map(settings.labelObs, (obs) => {
-        obs = obs || settings.data.obs[obs.name] || null;
-        return {
-          url: dataset.url,
-          path:
-            "obs/" +
-            obs.name +
-            (obs.type === OBS_TYPES.CATEGORICAL ? "/codes" : ""),
-          key: obs.name,
-        };
-      }),
+      _.compact(
+        _.map(settings.labelObs, (obsName) => {
+          const obs = settings.data.obs[obsName] || null;
+          return (
+            obs && {
+              url: dataset.url,
+              path:
+                "obs/" +
+                obs.name +
+                (obs.type === OBS_TYPES.CATEGORICAL ? "/codes" : ""),
+              key: obs.name,
+            }
+          );
+        })
+      ),
     [dataset.url, settings.data.obs, settings.labelObs]
   );
 

--- a/src/tests/ObsColsList.test.js
+++ b/src/tests/ObsColsList.test.js
@@ -6,8 +6,13 @@ import { render, screen } from "@testing-library/react";
 import { Wrapper } from "./setupTests";
 import { ObsColsList } from "../lib/components/obs-list/ObsList";
 import { useFetch } from "../lib/utils/requests";
+import { useResolver } from "../lib/utils/Resolver";
 
 test("renders ObsColsList component", () => {
+  useResolver.mockImplementation((initSettings) => {
+    return initSettings;
+  });
+
   useFetch.mockReturnValue({
     fetchedData: null,
     isPending: true,

--- a/src/tests/VarList.test.js
+++ b/src/tests/VarList.test.js
@@ -6,8 +6,24 @@ import { render, screen } from "@testing-library/react";
 import { Wrapper } from "./setupTests";
 import { VarNamesList } from "../lib/components/var-list/VarList";
 import { useDebouncedFetch, useFetch } from "../lib/utils/requests";
+import { useResolver } from "../lib/utils/Resolver";
 
 test("renders VarList component", async () => {
+  useResolver.mockImplementation((initSettings) => {
+    return {
+      ...initSettings,
+      data: {
+        vars: {
+          gene1: {
+            name: "gene1",
+            index: "gene1",
+            matrix_index: 0,
+          },
+        },
+      },
+    };
+  });
+
   useFetch.mockReturnValue({
     fetchedData: null,
     isPending: false,

--- a/src/tests/setupTests.js
+++ b/src/tests/setupTests.js
@@ -12,8 +12,6 @@ export const mockDataset = {
     vars: [
       {
         name: "gene1",
-        index: "gene1",
-        matrix_index: 0,
       },
     ],
   },
@@ -27,6 +25,14 @@ jest.mock("../lib/utils/requests", () => ({
   useFetch: jest.fn(),
   useDebouncedFetch: jest.fn(),
 }));
+
+jest.mock("../lib/utils/Resolver", () => {
+  const actual = jest.requireActual("../lib/utils/Resolver");
+  return {
+    ...actual,
+    useResolver: jest.fn(),
+  };
+});
 
 export const Wrapper = ({ children }) => {
   const queryClient = new QueryClient({


### PR DESCRIPTION
Refactor settings context so settings object contains a `data` key that holds the dataset resolved values of obs and vars, so the rest of the settings only hold string/numerical values that can be easily exported/imported or set in default settings for example.

Currently, only ObsList and VarList components perform the data fetching of obs and var, which on UI interaction sets a selection with all necessary data (e.g. when a user selects a var from the list, it has already loaded its data and is ready for other components). However, on initial loading, setting a default selection for a dataset requires specifying the whole object with dataset resolved data 
e.g. to set a selected var by default one would need to pass as prop
```js
defaultSettings: {
  selectedVar: { name: "Gene1", index: "Gene1", matrix_index: 123 }
}
```
having prior knowledge of what the `matrix_index` is, etc. The app would not validate whether the `matrix_index` matches the var so it could load the wrong data. Additionally, if the underlying dataset is updated the settings could be wrong as well. Same for obs selections.

By keeping dataset resolved values separately, settings can retain only the user-friendly values, thus the above prop would just be
```js
defaultSettings: {
  selectedVar: { name: "Gene1" }
}
```
and the app will perform the data fetching on initialization, which ensures data is up to date, and stores it in the `data` key of the settings provided by the settings context so it is still accessible to all components. The initialized settings would then look like
```js
{
  ...,
  selectedVar: { name: "Gene1" },
  data: {
    obs: ...,
    vars: {
      Gene1: { name: "Gene1", index: "Gene1", matrix_index: 123 } 
    }
  }
}
```

Added `useResolver` hook that performs the required data fetching to initialize the settings.
Added `useSelectedObs`, `useSelectedVar`, `useSelectedMultiVar` and `useSettingsVars` hooks for components to get the merged object (settings+data) to use just as `selectedObs`, etc., were used when they held the whole data.

Needs api changes from https://github.com/haniffalab/cherita-flask-api/pull/62
Fixes #126 