### PR TITLE
add collapsed view plot type selection

### DIFF
--- a/src/lib/components/full-page/FullPage.js
+++ b/src/lib/components/full-page/FullPage.js
@@ -59,6 +59,7 @@ export function FullPage({
   const XlBreakpoint = useMediaQuery(BREAKPOINTS.XL);
   const showObsBtn = LgBreakpoint;
   const showVarsBtn = XlBreakpoint;
+  const showPlotBtn = showVarsBtn;
 
   const { plotControls, varMode, showSelectedAsActive } = {
     [PLOT_TYPES.SCATTERPLOT]: {
@@ -125,7 +126,17 @@ export function FullPage({
               showColor={varMode === SELECTION_MODES.SINGLE}
             />
           </div>
-          <div className="cherita-app-canvas">{plot}</div>
+          <div className="cherita-app-canvas">
+            {showPlotBtn && (
+              <div className="px-3 py-2">
+                <PlotTypeSelector
+                  currentType={plotType}
+                  onChange={(type) => setPlotType(type)}
+                />
+              </div>
+            )}
+            {plot}
+          </div>
           <div className="cherita-app-sidebar p-3">
             <Card>
               <Card.Body>

--- a/src/lib/components/full-page/PlotTypeSelector.js
+++ b/src/lib/components/full-page/PlotTypeSelector.js
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { OverlayTrigger, Tooltip } from "react-bootstrap";
+
 import dotplotIcon from "../../../assets/images/plots/dotplot.svg";
 import heatmapIcon from "../../../assets/images/plots/heatmap.svg";
 import matrixplotIcon from "../../../assets/images/plots/matrixplot.svg";
@@ -25,19 +27,24 @@ export function PlotTypeSelector({ currentType, onChange }) {
   return (
     <div className="d-flex gap-2 justify-content-between">
       {plotTypes.map(({ type, icon, alt }) => (
-        <img
-          key={type}
-          src={icon}
-          alt={alt}
-          height={32}
-          width={32}
-          className={`plotselector-icon${currentType === type ? " active" : ""}`}
-          onClick={() => onChange(type)}
-          style={{
-            borderBottom: currentType === type ? "2px solid #007bff" : "none",
-          }}
-          title={alt}
-        />
+        <OverlayTrigger
+          placement="auto"
+          overlay={<Tooltip id={`tooltip-${alt}`}>{alt}</Tooltip>}
+        >
+          <img
+            key={type}
+            src={icon}
+            alt={alt}
+            height={32}
+            width={32}
+            className={`plotselector-icon${currentType === type ? " active" : ""}`}
+            onClick={() => onChange(type)}
+            style={{
+              borderBottom: currentType === type ? "2px solid #007bff" : "none",
+            }}
+            title={alt}
+          />
+        </OverlayTrigger>
       ))}
     </div>
   );


### PR DESCRIPTION
add PlotTypeSelector on top of fullpage plot in collapsed view
add tooltips to PlotTypeSelector

not added to spatial controls component as that is only present in scatterplot and not other plots

fixes #169 