### PR TITLE
fix: show error on ObsmKeysList instead of setting hasObsm to false

### DIFF
--- a/src/lib/components/obsm-list/ObsmList.jsx
+++ b/src/lib/components/obsm-list/ObsmList.jsx
@@ -24,7 +24,7 @@ export function ObsmKeysList({ setHasObsm }) {
   const dataset = useDataset();
   const settings = useSettings();
   const dispatch = useSettingsDispatch();
-  const [obsmKeysList, setObsmKeysList] = useState([]);
+  const [keysList, setKeysList] = useState([]);
   const [active, setActive] = useState(null);
 
   const params = useMemo(
@@ -39,10 +39,10 @@ export function ObsmKeysList({ setHasObsm }) {
   });
 
   useEffect(() => {
-    if (!isPending) {
-      if (serverError || !fetchedData || !fetchedData.length) {
+    if (!isPending && !serverError) {
+      if (!!fetchedData && !fetchedData.length) {
         setHasObsm(false);
-        setObsmKeysList([]);
+        setKeysList([]);
         if (settings.selectedObsm) {
           dispatch({
             type: 'select.obsm',
@@ -51,7 +51,7 @@ export function ObsmKeysList({ setHasObsm }) {
         }
       } else {
         setHasObsm(true);
-        setObsmKeysList(fetchedData);
+        setKeysList(fetchedData);
 
         if (settings.selectedObsm) {
           // If selected obsm is not in keys list, reset to null
@@ -81,6 +81,13 @@ export function ObsmKeysList({ setHasObsm }) {
           });
         }
       }
+    } else if (!isPending && serverError) {
+      if (settings.selectedObsm) {
+        dispatch({
+          type: 'select.obsm',
+          obsm: null,
+        });
+      }
     }
   }, [
     dispatch,
@@ -91,7 +98,7 @@ export function ObsmKeysList({ setHasObsm }) {
     settings.selectedObsm,
   ]);
 
-  const obsmList = obsmKeysList.map((item) => {
+  const obsmList = keysList.map((item) => {
     return (
       <Dropdown.Item
         key={item}


### PR DESCRIPTION
# Description

don't set hasObsm to false when request to obsm keys returns a serverError as it doesn't allow retries and message is misleading and hides error
also rename state variable obsmKeysList to keysList (so component doesn't share name)

Fixes #192

## Type of change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [ ] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [x] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
