### PR TITLE
Guard against null obsm keys

### DIFF
--- a/src/lib/components/obsm-list/ObsmList.jsx
+++ b/src/lib/components/obsm-list/ObsmList.jsx
@@ -40,7 +40,8 @@ export function ObsmKeysList({ setHasObsm }) {
 
   useEffect(() => {
     if (!isPending && !serverError) {
-      if (!!fetchedData && !fetchedData.length) {
+      const obsmKeysArray = Array.isArray(fetchedData) ? fetchedData : [];
+      if (obsmKeysArray.length === 0) {
         setHasObsm(false);
         setKeysList([]);
         if (settings.selectedObsm) {
@@ -51,11 +52,11 @@ export function ObsmKeysList({ setHasObsm }) {
         }
       } else {
         setHasObsm(true);
-        setKeysList(fetchedData);
+        setKeysList(obsmKeysArray);
 
         if (settings.selectedObsm) {
           // If selected obsm is not in keys list, reset to null
-          if (!_.includes(fetchedData, settings.selectedObsm)) {
+          if (!_.includes(obsmKeysArray, settings.selectedObsm)) {
             dispatch({
               type: 'select.obsm',
               obsm: null,
@@ -68,7 +69,7 @@ export function ObsmKeysList({ setHasObsm }) {
           // Follow DEFAULT_OBSM_KEYS order
           _.each(DEFAULT_OBSM_KEYS, (k) => {
             const defaultObsm = _.find(
-              fetchedData,
+              obsmKeysArray,
               (item) => item.toLowerCase() === k,
             );
             if (defaultObsm) {


### PR DESCRIPTION
# Description

The console error (`TypeError: Cannot read properties of null (reading 'map')`), indicates a failure when calling .map() in `ObsmList.jsx`. There is only one `.map()` [in that component](https://github.com/haniffalab/cherita-react/blob/525143586f04d4af61c4b7b771dae96de307a4cb/src/lib/components/obsm-list/ObsmList.jsx#L102), and so the `keysList` here must be `null` at render time.

`keysList` is initialized as `[]`, and the API always returns an array. Therefore, I think the fetch hook must be briefly exposing `fetchedData` as `null` during state transitions? 

If `fetchedData` is `null`, then the conditional "`if (!!fetchedData && !fetchedData.length) {`" is skipped, and the `null` value is then propagated into component state and later used with `.map()`, causing a runtime error in some timing-dependent cases in production.

The fix normalizes the fetched value to an empty array before it is used, ensuring the component state is always safe to render and hopefully eliminating the race condition.

Fixes #206

## Type of change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [ ] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [x] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
