### PR TITLE
fix: default canOverrideSettings in Plot component

### DIFF
--- a/src/lib/components/plot/Plot.jsx
+++ b/src/lib/components/plot/Plot.jsx
@@ -28,7 +28,6 @@ export function Plot({
   showObsBtn = true,
   showVarsBtn = true,
   showCtrlsBtn = true,
-  canOverrideSettings = false,
   ...props
 }) {
   const [showObs, setShowObs] = useState(false);
@@ -91,7 +90,7 @@ export function Plot({
   };
 
   return (
-    <DatasetProvider {...props}>
+    <DatasetProvider canOverrideSettings={false} {...props}>
       {plot()}
       <OffcanvasObs
         {...props}


### PR DESCRIPTION
# Description

fix default canOverrideSettings in Plot component

## Type of change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [ ] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [x] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
