### PR TITLE
Fix/scatterplot radius

### DIFF
--- a/src/lib/components/scatterplot/Scatterplot.jsx
+++ b/src/lib/components/scatterplot/Scatterplot.jsx
@@ -368,10 +368,10 @@ export function Scatterplot({
         pointInteractionEnabled &&
         getOriginalIndex(index) === selectedObsIndex
       ) {
-        return grayOut ? 200 : 200;
+        return 200;
       }
 
-      return grayOut ? 1 : 60;
+      return grayOut ? 1 : 3;
     },
     [
       getOriginalIndex,

--- a/src/lib/components/scatterplot/Scatterplot.jsx
+++ b/src/lib/components/scatterplot/Scatterplot.jsx
@@ -371,7 +371,7 @@ export function Scatterplot({
         return 200;
       }
 
-      return grayOut ? 1 : 3;
+      return (grayOut ? 1 : 3) * (pointInteractionEnabled ? 40 : 1);
     },
     [
       getOriginalIndex,

--- a/src/lib/components/scatterplot/Scatterplot.jsx
+++ b/src/lib/components/scatterplot/Scatterplot.jsx
@@ -345,6 +345,9 @@ export function Scatterplot({
     [
       isPending,
       sortedObsIndices,
+      pointInteractionEnabled,
+      getOriginalIndex,
+      selectedObsIndex,
       getColor,
       sortedData.values,
       min,
@@ -353,24 +356,30 @@ export function Scatterplot({
       useUnsColors,
       settings.colorEncoding,
       selectedObs?.colors,
-      selectedObsIndex,
-      getOriginalIndex,
     ],
   );
 
   // @TODO: add support for pseudospatial hover to reflect in radius
-  const getRadius = (_d, { index }) => {
-    const grayOut = sortedObsIndices && !sortedObsIndices.has(index);
+  const getRadius = useCallback(
+    (_d, { index }) => {
+      const grayOut = sortedObsIndices && !sortedObsIndices.has(index);
 
-    if (
-      pointInteractionEnabled &&
-      getOriginalIndex(index) === selectedObsIndex
-    ) {
-      return grayOut ? 200 : 200;
-    }
+      if (
+        pointInteractionEnabled &&
+        getOriginalIndex(index) === selectedObsIndex
+      ) {
+        return grayOut ? 200 : 200;
+      }
 
-    return grayOut ? 1 : 60;
-  };
+      return grayOut ? 1 : 60;
+    },
+    [
+      getOriginalIndex,
+      pointInteractionEnabled,
+      selectedObsIndex,
+      sortedObsIndices,
+    ],
+  );
 
   const memoizedLayers = useMemo(() => {
     return [
@@ -486,6 +495,10 @@ export function Scatterplot({
   const getLabel = (o, v, isVar = false) => {
     if (isVar || o.type === OBS_TYPES.CONTINUOUS) {
       return `${o.name}: ${formatNumerical(parseFloat(v))}`;
+    } else if (o.type === OBS_TYPES.DISCRETE) {
+      return `${o.name}: ${v}`;
+    } else if (o.type === OBS_TYPES.BOOLEAN) {
+      return `${o.name}: ${o.codesMap[+v]}`;
     } else {
       return `${o.name}: ${o.codesMap[v]}`;
     }


### PR DESCRIPTION
# Description

based off of fix/scatterplot-tooltip (#213)
Fix hardcoded scatterplot radius as they don't take into account the computation of getRadiusScale and make scatterplots with "smaller" bounds and less data points have overlapping dots 

Related to #215 , custom radius for datasets should be provided through settings

## Type of change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [ ] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [x] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
