### PR TITLE
feat: add scatterplot radiusScale slider to controls

### DIFF
--- a/src/lib/components/scatterplot/Scatterplot.jsx
+++ b/src/lib/components/scatterplot/Scatterplot.jsx
@@ -168,25 +168,24 @@ export function Scatterplot({
   ]);
 
   useEffect(() => {
-    if (data.positions && !!data.positions.length) {
+    if (data.positions && data.positions.length) {
       const mapHelper = new MapHelper();
-      setViewport(
-        mapHelper.fitBounds(data.positions, {
+      const { latitude, longitude, zoom, bounds } = mapHelper.fitBounds(
+        data.positions,
+        {
           width: deckRef?.current?.deck?.width,
           height: deckRef?.current?.deck?.height,
-        }),
+        },
       );
+      setViewState((v) => ({
+        ...v,
+        latitude,
+        longitude,
+        zoom,
+      }));
+      setViewport({ latitude, longitude, zoom, bounds });
     }
   }, [data.positions]);
-
-  useEffect(() => {
-    if (viewport) {
-      const { latitude, longitude, zoom } = viewport;
-      setViewState((v) => {
-        return { ...v, longitude: longitude, latitude: latitude, zoom: zoom };
-      });
-    }
-  }, [viewport]);
 
   useEffect(() => {
     if (

--- a/src/lib/components/scatterplot/Scatterplot.jsx
+++ b/src/lib/components/scatterplot/Scatterplot.jsx
@@ -380,7 +380,7 @@ export function Scatterplot({
         pointInteractionEnabled &&
         getOriginalIndex(index) === selectedObsIndex
       ) {
-        return 200;
+        return 90;
       }
 
       return (grayOut ? 1 : 3) * (pointInteractionEnabled ? 40 : 1);

--- a/src/lib/components/scatterplot/ScatterplotControls.jsx
+++ b/src/lib/components/scatterplot/ScatterplotControls.jsx
@@ -92,7 +92,7 @@ const RadiusScaleRange = ({ min = 1, max = 5000 }) => {
   return (
     <Box className="w-100">
       <Typography id="radius-scale-range" gutterBottom>
-        Dot radius scale
+        Point size
       </Typography>
       <div className="px-4">
         <Slider
@@ -122,6 +122,8 @@ export const ScatterplotControls = () => {
         <ColorscaleSelect />
         <Form.Group className="mb-2">
           <ColorscaleRange />
+        </Form.Group>
+        <Form.Group className="mb-2">
           <RadiusScaleRange />
         </Form.Group>
       </Form>

--- a/src/lib/components/scatterplot/ScatterplotControls.jsx
+++ b/src/lib/components/scatterplot/ScatterplotControls.jsx
@@ -108,6 +108,7 @@ const RadiusScaleRange = ({ min = 1, max = 5000 }) => {
           valueLabelFormat={valueLabelFormat}
           marks={!disabled && marks}
           disabled={disabled}
+          track={false}
         />
       </div>
     </Box>

--- a/src/lib/components/scatterplot/ScatterplotControls.jsx
+++ b/src/lib/components/scatterplot/ScatterplotControls.jsx
@@ -10,14 +10,12 @@ import {
   useSettingsDispatch,
 } from '../../context/SettingsContext';
 import { useSelectedObs } from '../../utils/Resolver';
+import { NormalizedRangeSlider } from '../../utils/Slider';
 import { ColorscaleSelect } from '../controls/Controls';
 
-export const ScatterplotControls = () => {
+const ColorscaleRange = () => {
   const settings = useSettings();
   const dispatch = useSettingsDispatch();
-  const [sliderValue, setSliderValue] = useState(
-    settings.controls.range || [0, 1],
-  );
   const { valueMin, valueMax } = useFilteredData();
 
   const selectedObs = useSelectedObs();
@@ -27,60 +25,103 @@ export const ScatterplotControls = () => {
       ? selectedObs?.type === OBS_TYPES.CATEGORICAL
       : false;
 
-  const valueLabelFormat = (value) => {
-    return (value * (valueMax - valueMin) + valueMin).toFixed(2);
-  };
-
-  const marks = [
-    { value: 0, label: valueLabelFormat(0) },
-    { value: 1, label: valueLabelFormat(1) },
-  ];
-
-  const updateSlider = (_e, value) => {
-    setSliderValue(value);
-  };
-
-  const updateRange = (_e, value) => {
-    setSliderValue(value);
+  const onChangeCommitted = (value) => {
     dispatch({
       type: 'set.controls.range',
-      range: sliderValue,
+      range: value,
     });
   };
 
-  useEffect(() => {
-    setSliderValue(settings.controls.range);
-  }, [settings.controls.range]);
+  const disabled = !settings.colorEncoding || isCategorical;
 
-  const rangeSlider = (
+  return (
     <Box className="w-100">
       <Typography id="colorscale-range" gutterBottom>
         Colorscale range
       </Typography>
       <div className="px-4">
-        <Slider
-          aria-labelledby="colorscale-range"
-          min={0}
-          max={1}
-          step={0.001}
-          value={sliderValue}
-          onChange={updateSlider}
-          onChangeCommitted={updateRange}
-          valueLabelDisplay="auto"
-          getAriaValueText={valueLabelFormat}
-          valueLabelFormat={valueLabelFormat}
-          marks={marks}
-          disabled={isCategorical}
+        <NormalizedRangeSlider
+          value={settings.controls.range}
+          valueMin={valueMin}
+          valueMax={valueMax}
+          disabled={disabled}
+          onChangeCommitted={onChangeCommitted}
         />
       </div>
     </Box>
   );
+};
 
+const RadiusScaleRange = ({ min = 1, max = 5000 }) => {
+  const settings = useSettings();
+  const dispatch = useSettingsDispatch();
+
+  const { selectedObsm } = settings;
+  const [sliderValue, setSliderValue] = useState(
+    settings.controls.radiusScale?.[selectedObsm] || 1,
+  );
+
+  useEffect(() => {
+    setSliderValue(settings.controls.radiusScale?.[selectedObsm] || 1);
+  }, [settings.controls.radiusScale, selectedObsm]);
+
+  const valueLabelFormat = (value) => {
+    return value.toFixed(0);
+  };
+
+  const marks = [
+    { value: min, label: 'smaller' },
+    { value: max, label: 'larger' },
+  ];
+
+  const onChange = (_e, value) => {
+    setSliderValue(value);
+  };
+
+  const onChangeCommitted = (_e, value) => {
+    dispatch({
+      type: 'set.controls.radiusScale',
+      obsm: selectedObsm,
+      radiusScale: value,
+    });
+  };
+
+  const disabled = !selectedObsm;
+
+  return (
+    <Box className="w-100">
+      <Typography id="radius-scale-range" gutterBottom>
+        Dot radius scale
+      </Typography>
+      <div className="px-4">
+        <Slider
+          aria-labelledby="radius-scale-range"
+          min={min}
+          max={max}
+          step={1}
+          value={sliderValue}
+          onChange={onChange}
+          onChangeCommitted={onChangeCommitted}
+          valueLabelDisplay="off"
+          getAriaValueText={valueLabelFormat}
+          valueLabelFormat={valueLabelFormat}
+          marks={!disabled && marks}
+          disabled={disabled}
+        />
+      </div>
+    </Box>
+  );
+};
+
+export const ScatterplotControls = () => {
   return (
     <>
       <Form>
         <ColorscaleSelect />
-        <Form.Group className="mb-2">{rangeSlider}</Form.Group>
+        <Form.Group className="mb-2">
+          <ColorscaleRange />
+          <RadiusScaleRange />
+        </Form.Group>
       </Form>
     </>
   );

--- a/src/lib/components/scatterplot/ScatterplotControls.jsx
+++ b/src/lib/components/scatterplot/ScatterplotControls.jsx
@@ -41,6 +41,7 @@ const ColorscaleRange = () => {
       </Typography>
       <div className="px-4">
         <NormalizedRangeSlider
+          aria-labelledby="colorscale-range"
           value={settings.controls.range}
           valueMin={valueMin}
           valueMax={valueMax}

--- a/src/lib/context/SettingsContext.jsx
+++ b/src/lib/context/SettingsContext.jsx
@@ -45,6 +45,7 @@ const initialSettings = {
     },
     meanOnlyExpressed: false,
     expressionCutoff: 0.0,
+    radiusScale: {},
   },
   varSort: {
     var: { sort: VAR_SORT.NONE, sortOrder: VAR_SORT_ORDER.ASC },
@@ -634,6 +635,18 @@ function settingsReducer(settings, action) {
         controls: {
           ...settings.controls,
           expressionCutoff: action.expressionCutoff,
+        },
+      };
+    }
+    case 'set.controls.radiusScale': {
+      return {
+        ...settings,
+        controls: {
+          ...settings.controls,
+          radiusScale: {
+            ...settings.controls.radiusScale,
+            [action.obsm]: action.radiusScale,
+          },
         },
       };
     }

--- a/src/lib/utils/Slider.jsx
+++ b/src/lib/utils/Slider.jsx
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+
+import { Slider } from '@mui/material';
+
+export const NormalizedRangeSlider = ({
+  value,
+  valueMin,
+  valueMax,
+  disabled,
+  onChangeCommitted = () => {},
+}) => {
+  const [sliderValue, setSliderValue] = useState(value);
+
+  useEffect(() => {
+    setSliderValue(value);
+  }, [value]);
+
+  const valueLabelFormat = (value) => {
+    return (value * (valueMax - valueMin) + valueMin).toFixed(2);
+  };
+
+  const marks = [
+    { value: 0, label: valueLabelFormat(0) },
+    { value: 1, label: valueLabelFormat(1) },
+  ];
+
+  const updateSlider = (_e, value) => {
+    setSliderValue(value);
+  };
+
+  const updateRange = (_e, value) => {
+    onChangeCommitted(value);
+  };
+
+  return (
+    <Slider
+      aria-labelledby="colorscale-range"
+      min={0}
+      max={1}
+      step={0.001}
+      value={sliderValue}
+      onChange={updateSlider}
+      onChangeCommitted={updateRange}
+      valueLabelDisplay="auto"
+      getAriaValueText={valueLabelFormat}
+      valueLabelFormat={valueLabelFormat}
+      marks={!disabled && marks}
+      disabled={disabled}
+    />
+  );
+};

--- a/src/lib/utils/Slider.jsx
+++ b/src/lib/utils/Slider.jsx
@@ -8,6 +8,7 @@ export const NormalizedRangeSlider = ({
   valueMax,
   disabled,
   onChangeCommitted = () => {},
+  ...props
 }) => {
   const [sliderValue, setSliderValue] = useState(value);
 
@@ -34,7 +35,6 @@ export const NormalizedRangeSlider = ({
 
   return (
     <Slider
-      aria-labelledby="colorscale-range"
       min={0}
       max={1}
       step={0.001}
@@ -46,6 +46,7 @@ export const NormalizedRangeSlider = ({
       valueLabelFormat={valueLabelFormat}
       marks={!disabled && marks}
       disabled={disabled}
+      {...props}
     />
   );
 };


### PR DESCRIPTION
# Description

add slider for scatterplot radiusScale to scatterplot controls
add radiusScale to settings.controls
move range slider into utils

Fixes #215 

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that resolves an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [ ] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [ ] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
