### PR TITLE
UI updates associated with ObsExplorer and PerturbGen study

### DIFF
--- a/src/lib/components/obs-list/ObsItem.jsx
+++ b/src/lib/components/obs-list/ObsItem.jsx
@@ -167,7 +167,7 @@ function CategoricalItem({
   const { getColor } = useColor();
 
   return (
-    <div className="virtualized-list-wrapper ps-1">
+    <div className="virtualized-list-wrapper ps-1" key={value}>
       <ListGroup.Item key={value} className="obs-item">
         <div className="d-flex align-items-center flex-wrap">
           <div className="flex-grow-1 me-auto mw-100">

--- a/src/lib/components/obs-list/ObsItem.jsx
+++ b/src/lib/components/obs-list/ObsItem.jsx
@@ -167,7 +167,7 @@ function CategoricalItem({
   const { getColor } = useColor();
 
   return (
-    <div className="virtualized-list-wrapper">
+    <div className="virtualized-list-wrapper ps-1">
       <ListGroup.Item key={value} className="obs-item">
         <div className="d-flex align-items-center flex-wrap">
           <div className="flex-grow-1 me-auto mw-100">

--- a/src/lib/components/offcanvas/OffCanvas.jsx
+++ b/src/lib/components/offcanvas/OffCanvas.jsx
@@ -72,7 +72,7 @@ export function OffcanvasObsExplorer({ show, handleClose, ...props }) {
   return (
     <Offcanvas show={show} onHide={handleClose}>
       <Offcanvas.Header closeButton>
-        <Offcanvas.Title>Controls</Offcanvas.Title>
+        <Offcanvas.Title>Features</Offcanvas.Title>
       </Offcanvas.Header>
       <Offcanvas.Body>
         <div className="sidebar-features">

--- a/src/lib/components/scatterplot/Scatterplot.jsx
+++ b/src/lib/components/scatterplot/Scatterplot.jsx
@@ -384,7 +384,7 @@ export function Scatterplot({
         return 50;
       }
 
-      return (grayOut ? 1 : 3) * (pointInteractionEnabled ? 5 : 1);
+      return (grayOut ? 1 : 3) * (pointInteractionEnabled ? 20 : 1);
     },
     [
       getOriginalIndex,

--- a/src/lib/components/search-bar/SearchBar.jsx
+++ b/src/lib/components/search-bar/SearchBar.jsx
@@ -85,6 +85,7 @@ export function SearchModal({
   });
   const [varResultsLength, setVarResultsLength] = useState(null);
   const [diseaseResultsLength, setDiseaseResultsLength] = useState(null);
+  const [obsResultsLength, setObsResultsLength] = useState(null);
 
   return (
     <Modal show={show} onHide={handleClose} size="xl" fullscreen="xl-down">
@@ -117,6 +118,7 @@ export function SearchModal({
                           });
                           setVarResultsLength(null);
                           setDiseaseResultsLength(null);
+                          setObsResultsLength(null);
                         }}
                       />
                       <Button variant="light" onClick={handleClose}>
@@ -159,8 +161,7 @@ export function SearchModal({
                         <Nav.Item>
                           <Nav.Link eventKey={FEATURE_TYPE.OBS}>
                             Genes{' '}
-                            {!!diseaseResultsLength &&
-                              `(${diseaseResultsLength})`}
+                            {!!obsResultsLength && `(${obsResultsLength})`}
                           </Nav.Link>
                         </Nav.Item>
                       )}
@@ -208,7 +209,7 @@ export function SearchModal({
                                 return { ...prev, obs: item };
                               })
                             }
-                            setResultsLength={setVarResultsLength}
+                            setResultsLength={setObsResultsLength}
                             handleClose={handleClose}
                           />
                         </Tab.Pane>

--- a/src/lib/components/search-bar/SearchBar.jsx
+++ b/src/lib/components/search-bar/SearchBar.jsx
@@ -130,12 +130,12 @@ export function SearchModal({
           </Row>
         </Container>
       </Modal.Header>
-      <Modal.Body className="p-0">
-        <Container>
-          <Row>
+      <Modal.Body className="p-0 h-100">
+        <Container className="h-100">
+          <Row className="h-100">
             <Col xs={12} md={8}>
               <Tab.Container activeKey={tab} onSelect={(k) => setTab(k)}>
-                <Row className="w-100">
+                <Row className="w-100 h-100">
                   <Col sm={3} className="py-3 border-end">
                     <Nav variant="pills" className="flex-column">
                       {searchVar && (

--- a/src/lib/components/search-bar/SearchInfo.jsx
+++ b/src/lib/components/search-bar/SearchInfo.jsx
@@ -120,28 +120,30 @@ export function DiseaseInfo({ disease, handleSelect, addVarSet }) {
 
   const diseaseVarList = _.map(sortedDiseaseVars, (v) => {
     return (
-      <ListGroup.Item key={v.gene_id}>
-        <div className="d-flex justify-content-between align-items-center w-100">
-          {v.name}
-          <div className="d-flex align-items-center gap-1">
-            <Button
-              type="button"
-              className="m-0 p-0 px-1"
-              variant="outline-secondary"
-              title="Add to list"
-              onClick={() => {
-                handleSelect(dispatch, {
-                  name: v.name,
-                  index: v.index,
-                  matrix_index: v.matrix_index,
-                });
-              }}
-            >
-              <FontAwesomeIcon icon={faPlus} />
-            </Button>
+      <div className="virtualized-list-wrapper">
+        <ListGroup.Item key={v.gene_id}>
+          <div className="d-flex justify-content-between align-items-center w-100">
+            {v.name}
+            <div className="d-flex align-items-center gap-1">
+              <Button
+                type="button"
+                className="m-0 p-0 px-1"
+                variant="outline-secondary"
+                title="Add to list"
+                onClick={() => {
+                  handleSelect(dispatch, {
+                    name: v.name,
+                    index: v.index,
+                    matrix_index: v.matrix_index,
+                  });
+                }}
+              >
+                <FontAwesomeIcon icon={faPlus} />
+              </Button>
+            </div>
           </div>
-        </div>
-      </ListGroup.Item>
+        </ListGroup.Item>
+      </div>
     );
   });
 

--- a/src/lib/components/search-bar/SearchInfo.jsx
+++ b/src/lib/components/search-bar/SearchInfo.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Tooltip from '@mui/material/Tooltip';
 import _ from 'lodash';
 import { Button, ListGroup } from 'react-bootstrap';
 
@@ -12,6 +13,7 @@ import {
   useSettingsDispatch,
 } from '../../context/SettingsContext';
 import { useFetch } from '../../utils/requests';
+import { useNCBIData } from '../../utils/useNCBIData';
 import { VarDiseaseInfo } from '../var-list/VarItem';
 import { sortMeans, useVarMean } from '../var-list/VarList';
 
@@ -32,6 +34,15 @@ export function VarInfo({ varItem }) {
     });
   }, [varItem.name]);
 
+  const {
+    fetchedData: ncbiData,
+    isPending: isNCBIPending,
+    serverError: ncbiError,
+  } = useNCBIData({ symbol: varItem.name });
+
+  const geneDescription =
+    ncbiData?.reports?.[0]?.gene?.summary?.[0]?.description;
+
   const { fetchedData, isPending, serverError } = useFetch(ENDPOINT, params, {
     refetchOnMount: false,
     enabled: !!dataset.diseaseDatasets.length,
@@ -41,11 +52,50 @@ export function VarInfo({ varItem }) {
 
   return (
     <div>
-      <h5>{varItem.name}</h5>
+      <h2>{varItem.name}</h2>
+      {isNCBIPending && (
+        <p className="text-muted small">Loading gene description…</p>
+      )}
+      {!isNCBIPending && !ncbiError && geneDescription && (
+        <>
+          <p className="small">{geneDescription}</p>
+          <p className="text-muted small">
+            Data fetched from{' '}
+            <a
+              href="https://www.ncbi.nlm.nih.gov/datasets/docs/v2/api/rest-api/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              NCBI API
+            </a>
+            {' · '}
+            <a
+              href={`https://www.ncbi.nlm.nih.gov/gene/?term=${encodeURIComponent(varItem.name)}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Gene page
+            </a>
+          </p>
+        </>
+      )}
       {!!dataset.diseaseDatasets.length && isPending && <p>Loading...</p>}
       {hasDiseaseInfo && (
         <>
-          <h6>Associated diseases</h6>
+          <h5 className="fw-bold mb-2">
+            <Tooltip
+              title={
+                <>
+                  Reported and inferred diseases associated with this gene,
+                  including supporting metadata.
+                </>
+              }
+              placement="left"
+              arrow
+            >
+              Associated Diseases
+            </Tooltip>
+          </h5>
           <VarDiseaseInfo data={fetchedData} />
         </>
       )}

--- a/src/lib/components/search-bar/SearchInfo.jsx
+++ b/src/lib/components/search-bar/SearchInfo.jsx
@@ -170,7 +170,7 @@ export function DiseaseInfo({ disease, handleSelect, addVarSet }) {
 
   const diseaseVarList = _.map(sortedDiseaseVars, (v) => {
     return (
-      <div className="virtualized-list-wrapper">
+      <div className="virtualized-list-wrapper" key={v.gene_id}>
         <ListGroup.Item key={v.gene_id}>
           <div className="d-flex justify-content-between align-items-center w-100">
             {v.name}

--- a/src/lib/components/search-bar/SearchResults.jsx
+++ b/src/lib/components/search-bar/SearchResults.jsx
@@ -113,25 +113,27 @@ export function VarSearchResults(props) {
         setSelectedResult,
         isStale,
       }) => (
-        <ListGroup.Item
-          key={item.index ?? item.name}
-          onClick={() => setSelectedResult(item)}
-          active={selectedResult?.index === item.index}
-        >
-          <div className="d-flex justify-content-between align-items-center w-100">
-            <div>{item.name}</div>
-            <Button
-              type="button"
-              className="m-0 p-0 px-1"
-              variant="outline-secondary"
-              title="Add to list"
-              disabled={isStale}
-              onClick={() => handleSelect(dispatch, item)}
-            >
-              <FontAwesomeIcon icon={faPlus} />
-            </Button>
-          </div>
-        </ListGroup.Item>
+        <div className="virtualized-list-wrapper">
+          <ListGroup.Item
+            key={item.index ?? item.name}
+            onClick={() => setSelectedResult(item)}
+            active={selectedResult?.index === item.index}
+          >
+            <div className="d-flex justify-content-between align-items-center w-100">
+              <div>{item.name}</div>
+              <Button
+                type="button"
+                className="m-0 p-0 px-1"
+                variant="outline-secondary"
+                title="Add to list"
+                disabled={isStale}
+                onClick={() => handleSelect(dispatch, item)}
+              >
+                <FontAwesomeIcon icon={faPlus} />
+              </Button>
+            </div>
+          </ListGroup.Item>
+        </div>
       )}
     />
   );
@@ -157,25 +159,27 @@ export function ObsSearchResults(props) {
         };
 
         return (
-          <ListGroup.Item
-            key={item.matrix_index}
-            onClick={() => setSelectedResult(item)}
-            active={selectedResult?.matrix_index === item.matrix_index}
-          >
-            <div className="d-flex justify-content-between align-items-center w-100">
-              <div>{item.name}</div>
-              <Button
-                type="button"
-                className="m-0 p-0 px-1"
-                variant="outline-secondary"
-                title="Add to list"
-                disabled={isStale}
-                onClick={() => onObsSelect(dispatch, item, props.handleClose)}
-              >
-                <FontAwesomeIcon icon={faPlus} />
-              </Button>
-            </div>
-          </ListGroup.Item>
+          <div className="virtualized-list-wrapper">
+            <ListGroup.Item
+              key={item.matrix_index}
+              onClick={() => setSelectedResult(item)}
+              active={selectedResult?.matrix_index === item.matrix_index}
+            >
+              <div className="d-flex justify-content-between align-items-center w-100">
+                <div>{item.name}</div>
+                <Button
+                  type="button"
+                  className="m-0 p-0 px-1"
+                  variant="outline-secondary"
+                  title="Add to list"
+                  disabled={isStale}
+                  onClick={() => onObsSelect(dispatch, item, props.handleClose)}
+                >
+                  <FontAwesomeIcon icon={faPlus} />
+                </Button>
+              </div>
+            </ListGroup.Item>
+          </div>
         );
       }}
     />
@@ -191,15 +195,17 @@ export function DiseasesSearchResults(props) {
       overscan={250}
       estimateSize={() => 32}
       itemRenderer={({ item, setSelectedResult, selectedResult }) => (
-        <ListGroup.Item
-          key={item.id ?? item.name}
-          onClick={() => setSelectedResult(item)}
-          active={selectedResult?.id === item.id}
-        >
-          <div className="d-flex justify-content-between align-items-center w-100">
-            <div>{item.disease_name}</div>
-          </div>
-        </ListGroup.Item>
+        <div className="virtualized-list-wrapper">
+          <ListGroup.Item
+            key={item.id ?? item.name}
+            onClick={() => setSelectedResult(item)}
+            active={selectedResult?.id === item.id}
+          >
+            <div className="d-flex justify-content-between align-items-center w-100">
+              <div>{item.disease_name}</div>
+            </div>
+          </ListGroup.Item>
+        </div>
       )}
     />
   );

--- a/src/lib/components/search-bar/SearchResults.jsx
+++ b/src/lib/components/search-bar/SearchResults.jsx
@@ -113,7 +113,7 @@ export function VarSearchResults(props) {
         setSelectedResult,
         isStale,
       }) => (
-        <div className="virtualized-list-wrapper">
+        <div className="virtualized-list-wrapper" key={item.index ?? item.name}>
           <ListGroup.Item
             key={item.index ?? item.name}
             onClick={() => setSelectedResult(item)}
@@ -159,7 +159,7 @@ export function ObsSearchResults(props) {
         };
 
         return (
-          <div className="virtualized-list-wrapper">
+          <div className="virtualized-list-wrapper" key={item.matrix_index}>
             <ListGroup.Item
               key={item.matrix_index}
               onClick={() => setSelectedResult(item)}
@@ -195,7 +195,7 @@ export function DiseasesSearchResults(props) {
       overscan={250}
       estimateSize={() => 32}
       itemRenderer={({ item, setSelectedResult, selectedResult }) => (
-        <div className="virtualized-list-wrapper">
+        <div className="virtualized-list-wrapper" key={item.id ?? item.name}>
           <ListGroup.Item
             key={item.id ?? item.name}
             onClick={() => setSelectedResult(item)}

--- a/src/lib/components/var-list/VarList.jsx
+++ b/src/lib/components/var-list/VarList.jsx
@@ -135,7 +135,7 @@ export function VarNamesList({
 
   const makeListItem = (item) => {
     return (
-      <div className="virtualized-list-wrapper">
+      <div className="virtualized-list-wrapper" key={item.matrix_index}>
         <ListGroup.Item key={item.matrix_index}>
           <VarItem item={item} active={active} mode={mode} />
         </ListGroup.Item>
@@ -145,7 +145,7 @@ export function VarNamesList({
 
   const makeSetListItem = (set) => {
     return (
-      <div className="virtualized-list-wrapper">
+      <div className="virtualized-list-wrapper" key={set.name}>
         <ListGroup.Item key={set.name}>
           <VarSet set={set} active={active} mode={mode} />
         </ListGroup.Item>

--- a/src/lib/components/var-list/VarList.jsx
+++ b/src/lib/components/var-list/VarList.jsx
@@ -135,17 +135,21 @@ export function VarNamesList({
 
   const makeListItem = (item) => {
     return (
-      <ListGroup.Item key={item.matrix_index}>
-        <VarItem item={item} active={active} mode={mode} />
-      </ListGroup.Item>
+      <div className="virtualized-list-wrapper">
+        <ListGroup.Item key={item.matrix_index}>
+          <VarItem item={item} active={active} mode={mode} />
+        </ListGroup.Item>
+      </div>
     );
   };
 
   const makeSetListItem = (set) => {
     return (
-      <ListGroup.Item key={set.name}>
-        <VarSet set={set} active={active} mode={mode} />
-      </ListGroup.Item>
+      <div className="virtualized-list-wrapper">
+        <ListGroup.Item key={set.name}>
+          <VarSet set={set} active={active} mode={mode} />
+        </ListGroup.Item>
+      </div>
     );
   };
 

--- a/src/lib/utils/VirtualizedTable.jsx
+++ b/src/lib/utils/VirtualizedTable.jsx
@@ -15,9 +15,25 @@ import { TableVirtuoso } from 'react-virtuoso';
 import { TableRowSkeleton } from './Skeleton';
 
 const TableComponents = {
-  Scroller: forwardRef((props, ref) => (
-    <TableContainer component={Paper} {...props} ref={ref} />
-  )),
+  Scroller: forwardRef((props, ref) => {
+    const { sx, ...rest } = props;
+
+    return (
+      <TableContainer
+        component={Paper}
+        ref={ref}
+        {...rest}
+        sx={[
+          {
+            marginBottom: 2,
+            border: 1,
+            borderColor: 'divider',
+          },
+          sx,
+        ]}
+      />
+    );
+  }),
   Table: (props) => (
     <MuiTable {...props} style={{ borderCollapse: 'separate' }} size="small" />
   ),

--- a/src/lib/utils/useNCBIData.jsx
+++ b/src/lib/utils/useNCBIData.jsx
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+
+export const useNCBIData = ({ symbol }) => {
+  const {
+    data: fetchedData = null,
+    isLoading: isPending,
+    error: serverError,
+  } = useQuery({
+    queryKey: ['ncbiData', symbol],
+    queryFn: async () => {
+      const response = await fetch(
+        `https://api.ncbi.nlm.nih.gov/datasets/v2/gene/symbol/${symbol}/taxon/human?page_size=1`,
+        { method: 'GET' },
+      );
+
+      if (!response.ok) {
+        throw new Error('Error fetching NCBI data');
+      }
+
+      return response.json();
+    },
+    enabled: Boolean(symbol),
+  });
+
+  return { fetchedData, isPending, serverError };
+};

--- a/src/lib/views/PerturbationMap/ObsExplorer.jsx
+++ b/src/lib/views/PerturbationMap/ObsExplorer.jsx
@@ -10,7 +10,6 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableRow from '@mui/material/TableRow';
 import Tooltip from '@mui/material/Tooltip';
-import { useQuery } from '@tanstack/react-query';
 import _ from 'lodash';
 import { Alert, Modal } from 'react-bootstrap';
 
@@ -20,32 +19,9 @@ import { useSettings } from '../../context/SettingsContext';
 import { useParquet, useParquetQuery } from '../../utils/parquetData';
 import { DataTableSkeleton } from '../../utils/Skeleton';
 import { formatNumerical } from '../../utils/string';
+import { useNCBIData } from '../../utils/useNCBIData';
 import { VirtualizedTable } from '../../utils/VirtualizedTable';
 import { useObsColsData } from '../../utils/zarrData';
-
-const useNCBIData = ({ symbol }) => {
-  const {
-    data: fetchedData = null,
-    isLoading: isPending = false,
-    error: serverError = null,
-  } = useQuery({
-    queryKey: ['ncbiData', symbol],
-    queryFn: async () => {
-      const reponse = await fetch(
-        `https://api.ncbi.nlm.nih.gov/datasets/v2/gene/symbol/${symbol}/taxon/human?page_size=1`,
-        {
-          method: 'GET',
-        },
-      );
-      if (!reponse.ok) {
-        throw new Error('Error fetching NCBI data');
-      }
-      return await reponse.json();
-    },
-    enabled: !!symbol,
-  });
-  return { fetchedData, isPending, serverError };
-};
 
 const NCBIData = ({ symbol }) => {
   const { fetchedData, isPending, serverError } = useNCBIData({ symbol });

--- a/src/lib/views/PerturbationMap/ObsExplorer.jsx
+++ b/src/lib/views/PerturbationMap/ObsExplorer.jsx
@@ -175,7 +175,7 @@ export function ObsExplorer() {
             placement="right"
             arrow
           >
-            {colsData?.[obsExplorer.symbolCol]}
+            <span>{colsData?.[obsExplorer.symbolCol]}</span>
           </Tooltip>
         </h2>
         <NCBIData symbol={colsData?.[obsExplorer.symbolCol]} />
@@ -192,7 +192,9 @@ export function ObsExplorer() {
               placement="right"
               arrow
             >
-              Perturbation metadata <InfoOutlinedIcon fontSize="small" />
+              <span>
+                Perturbation metadata <InfoOutlinedIcon fontSize="small" />
+              </span>
             </Tooltip>
           </h5>
 
@@ -234,41 +236,43 @@ export function ObsExplorer() {
             </Table>
           </TableContainer>
         </div>
-        <div className="mb-3">
-          <h5 className="fw-bold mb-2 d-flex align-items-center justify-content-between">
-            <Tooltip
-              title={
-                <>
-                  This table shows genes predicted to change exp ression i
-                  response to the selected perturbation. Re sults can be sor and
-                  explored to identify affect ed pathways and regulatory
-                  programs.
-                </>
-              }
-              placement="right"
-              arrow
-            >
-              <span
-                className="d-i{' '}
-               nline-flex align-items-center"
+        {obsExplorer?.dataUrl && (
+          <div className="mb-3">
+            <h5 className="fw-bold mb-2 d-flex align-items-center justify-content-between">
+              <Tooltip
+                title={
+                  <>
+                    This table shows genes predicted to change expression in
+                    response to the selected perturbation. Results can be sorted
+                    and explored to identify affected pathways and regulatory
+                    programs.
+                  </>
+                }
+                placement="right"
+                arrow
               >
-                Predicted downstream effects{' '}
-                <InfoOutlinedIcon fontSize="small" className="ms-1" />
-              </span>
-            </Tooltip>
+                <span
+                  className="d-i{' '}
+               nline-flex align-items-center"
+                >
+                  Predicted downstream effects{' '}
+                  <InfoOutlinedIcon fontSize="small" className="ms-1" />
+                </span>
+              </Tooltip>
 
-            {/* MUI expand icon */}
-            <IconButton
-              size="small"
-              onClick={() => setShowModal(true)}
-              aria-label="Expand full table"
-            >
-              <OpenInFullIcon fontSize="small" />
-            </IconButton>
-          </h5>
+              {/* MUI expand icon */}
+              <IconButton
+                size="small"
+                onClick={() => setShowModal(true)}
+                aria-label="Expand full table"
+              >
+                <OpenInFullIcon fontSize="small" />
+              </IconButton>
+            </h5>
 
-          <ObsExplorerTable colsData={colsData} />
-        </div>
+            <ObsExplorerTable colsData={colsData} />
+          </div>
+        )}
         <Modal
           show={showModal}
           onHide={() => setShowModal(false)}

--- a/src/scss/cherita.scss
+++ b/src/scss/cherita.scss
@@ -440,7 +440,7 @@ input[type='checkbox'] {
 .cherita-search-modal {
   .form-control:focus {
     box-shadow: none;
-    border: var(--bs-border-width) solid var(--bs-border-color);
+    border: var(--geeks-border-width) solid var(--geeks-input-border);
   }
 }
 

--- a/src/scss/components/layouts.scss
+++ b/src/scss/components/layouts.scss
@@ -137,7 +137,6 @@
 
 .search-modal-info {
   overflow-y: auto;
-  border-left: 1px solid #dee2e6;
 }
 
 .cherita-app-canvas {

--- a/src/scss/components/lists.scss
+++ b/src/scss/components/lists.scss
@@ -1,6 +1,6 @@
 .list-group.cherita-list {
   .virtualized-list-wrapper {
-    padding: 0 0.25rem 0.25rem;
+    padding-bottom: 0.25rem;
   }
 
   .list-group-item.unstyled {


### PR DESCRIPTION
# Description

This PR includes several UI updates and improvements related to usage of ObsExplorer and PerturbGen study data

- Standarised usage of `virtualized-list-wrapper` class across all lists. Fixes minor styling issues.
- Increased base radius size in Scatterplot when `pointInteractionEnabled` is true, making points larger in PerturbGen study data
- Fixes a styling issue in the search results, to ensure the columns extend to the full height of the container
- Included NCBI gene descriptions with the search results for genes
- Extracted to `useNCBIData` to utils
- Set explicit border styling to `VirtualizedTable`
- ObsExplorer update: include NCBI description with link to their website
- ObsExplorer update: include descriptive tooltips on headers
- ObsExplorer update: update metadata table to use MUI components
- ObsExplorer update: include option to open full table in modal

## Type of change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [ ] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [ ] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
