### PR TITLE
PerturbationMap views

### DIFF
--- a/sites/demo/src/App.jsx
+++ b/sites/demo/src/App.jsx
@@ -10,6 +10,7 @@ import Header from './components/Header';
 import DotplotDemo from './containers/DotplotDemo';
 import HeatmapDemo from './containers/HeatmapDemo';
 import MatrixplotDemo from './containers/MatrixplotDemo';
+import PerturbationMapEmbeddedPlotDemo from './containers/PerturbationMap/EmbeddedPlotDemo';
 import ScatterplotDemo from './containers/ScatterplotDemo';
 import ViolinDemo from './containers/ViolinDemo';
 
@@ -104,6 +105,11 @@ export default function App(props) {
           exact
           path="/perturbation-map/standard-view"
           element={<PerturbationMap.StandardView {...props} />}
+        />
+        <Route
+          exact
+          path="/perturbation-map/embedded-plot"
+          element={<PerturbationMapEmbeddedPlotDemo {...props} />}
         />
       </Routes>
       <Footer />

--- a/sites/demo/src/components/Header.jsx
+++ b/sites/demo/src/components/Header.jsx
@@ -83,7 +83,11 @@ export default function Header() {
             <NavDropdown title="PerturbationMap" id="perturbation-map-dropdown">
               <NavDropdown.Header>Standard Views</NavDropdown.Header>
               <NavDropdown.Item as={Link} to="perturbation-map/standard-view">
-                PerturbGen
+                StandardView
+              </NavDropdown.Item>
+              <NavDropdown.Header>Embedded Plots</NavDropdown.Header>
+              <NavDropdown.Item as={Link} to="perturbation-map/embedded-plot">
+                EmbeddedPlot
               </NavDropdown.Item>
             </NavDropdown>
           </Nav>

--- a/sites/demo/src/containers/PerturbationMap/EmbeddedPlotDemo.jsx
+++ b/sites/demo/src/containers/PerturbationMap/EmbeddedPlotDemo.jsx
@@ -1,0 +1,14 @@
+import { PerturbationMap } from '@haniffalab/cherita-react';
+import Container from 'react-bootstrap/Container';
+
+export default function PerturbationMapEmbeddedPlotDemo(props) {
+  return (
+    <div className="h-100">
+      <Container>
+        <div className="cherita-container">
+          <PerturbationMap.EmbeddedPlot {...props} />
+        </div>
+      </Container>
+    </div>
+  );
+}

--- a/src/lib/components/offcanvas/OffCanvas.jsx
+++ b/src/lib/components/offcanvas/OffCanvas.jsx
@@ -72,9 +72,9 @@ export function OffcanvasObsExplorer({ show, handleClose, ...props }) {
   return (
     <Offcanvas show={show} onHide={handleClose}>
       <Offcanvas.Header closeButton>
-        <Offcanvas.Title>Features</Offcanvas.Title>
+        <Offcanvas.Title>Gene Perturbations</Offcanvas.Title>
       </Offcanvas.Header>
-      <Offcanvas.Body>
+      <Offcanvas.Body className="p-1">
         <div className="sidebar-features">
           <SearchBar
             searchDiseases={false}

--- a/src/lib/components/scatterplot/Scatterplot.jsx
+++ b/src/lib/components/scatterplot/Scatterplot.jsx
@@ -38,6 +38,7 @@ import { Legend } from '../../utils/Legend';
 import { LoadingLinear, LoadingSpinner } from '../../utils/LoadingIndicators';
 import { useSelectedObs } from '../../utils/Resolver';
 import { formatNumerical } from '../../utils/string';
+import usePlotVisibility from '../../utils/usePlotVisibility';
 import { useLabelObsData } from '../../utils/zarrData';
 import { PlotAlert } from '../plot/PlotAlert';
 
@@ -95,6 +96,7 @@ export function Scatterplot({
 
   const [hoveredIndex, setHoveredIndex] = useState(null);
   const [isHoveringPoint, setIsHoveringPoint] = useState(false);
+  const { showSearchBtn } = usePlotVisibility(isFullscreen);
 
   // EditableGeoJsonLayer
   const [mode, setMode] = useState(() => ViewMode);
@@ -384,7 +386,7 @@ export function Scatterplot({
         return 50;
       }
 
-      return (grayOut ? 1 : 3) * (pointInteractionEnabled ? 20 : 1);
+      return (grayOut ? 1 : 3) * (pointInteractionEnabled ? 26 : 1);
     },
     [
       getOriginalIndex,
@@ -502,6 +504,10 @@ export function Scatterplot({
       clickedInsideRef.current = true;
       const originalIndex = getOriginalIndex(info.index);
       dispatch({ type: 'set.selectedObsIndex', index: originalIndex });
+      // in collapsed view, open offcanvas
+      if (pointInteractionEnabled && showSearchBtn) {
+        setShowSearch(true);
+      }
     }
   }
 

--- a/src/lib/views/ObservationFeature/EmbeddedPlot.jsx
+++ b/src/lib/views/ObservationFeature/EmbeddedPlot.jsx
@@ -71,6 +71,7 @@ export function EmbeddedPlot({
     setShowCategories,
     setShowSearch,
     setShowControls,
+    ...props,
   };
 
   const plot = () => {

--- a/src/lib/views/ObservationFeature/StandardView.jsx
+++ b/src/lib/views/ObservationFeature/StandardView.jsx
@@ -90,6 +90,7 @@ export function StandardView({
       setShowSearch,
       setShowControls,
       setPlotType,
+      ...props,
     };
 
     switch (plotType) {

--- a/src/lib/views/PerturbationMap/EmbeddedPlot.jsx
+++ b/src/lib/views/PerturbationMap/EmbeddedPlot.jsx
@@ -25,7 +25,7 @@ export function EmbeddedPlot({ showCtrlsBtn = true, ...props }) {
 
   return (
     <DatasetProvider canOverrideSettings={false} {...props}>
-      <Scatterplot {...commonProps} />
+      <Scatterplot {...commonProps} pointInteractionEnabled={true} />
       <OffcanvasObs
         {...props}
         showSelectedAsActive={false}

--- a/src/lib/views/PerturbationMap/EmbeddedPlot.jsx
+++ b/src/lib/views/PerturbationMap/EmbeddedPlot.jsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+
+import {
+  OffcanvasControls,
+  OffcanvasObs,
+  OffcanvasObsExplorer,
+  OffcanvasObsm,
+} from '../../components/offcanvas/OffCanvas';
+import { Scatterplot } from '../../components/scatterplot/Scatterplot';
+import { ScatterplotControls } from '../../components/scatterplot/ScatterplotControls';
+import { DatasetProvider } from '../../context/DatasetContext';
+
+export function EmbeddedPlot({ showCtrlsBtn = true, ...props }) {
+  const [showCategories, setShowCategories] = useState(false);
+  const [showEmbeddings, setShowEmbeddings] = useState(false);
+  const [showSearch, setShowSearch] = useState(false);
+  const [showControls, setShowControls] = useState(false);
+
+  const commonProps = {
+    setShowCategories,
+    setShowSearch,
+    setShowControls,
+    ...props,
+  };
+
+  return (
+    <DatasetProvider canOverrideSettings={false} {...props}>
+      <Scatterplot {...commonProps} />
+      <OffcanvasObs
+        {...props}
+        showSelectedAsActive={false}
+        show={showCategories}
+        handleClose={() => setShowCategories(false)}
+      />
+      <OffcanvasObsExplorer
+        {...props}
+        show={showSearch}
+        handleClose={() => setShowSearch(false)}
+      />
+      <OffcanvasControls
+        {...props}
+        show={showControls}
+        handleClose={() => setShowControls(false)}
+        Controls={ScatterplotControls}
+      />
+      <OffcanvasObsm
+        {...props}
+        show={showEmbeddings}
+        handleClose={() => setShowEmbeddings(false)}
+      />
+    </DatasetProvider>
+  );
+}

--- a/src/lib/views/PerturbationMap/index.js
+++ b/src/lib/views/PerturbationMap/index.js
@@ -1,5 +1,7 @@
+import { EmbeddedPlot } from './EmbeddedPlot';
 import { StandardView } from './StandardView';
 
 export const PerturbationMap = {
+  EmbeddedPlot,
   StandardView,
 };


### PR DESCRIPTION
# Description

Brief summary of changes:
- Fix #232 to show ObsExplorer on interaction under XL breakpoint
- Added EmbeddedPlot to PerturbationMap group of views

Fixes #232 

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [ ] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [ ] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
