### PR TITLE
Use dataset defined labels instead of hard-coded “cells” and “genes”

### DIFF
--- a/src/lib/components/dotplot/Dotplot.jsx
+++ b/src/lib/components/dotplot/Dotplot.jsx
@@ -199,10 +199,10 @@ export function Dotplot({
               className="border-0 p-0 align-baseline"
               onClick={setShowSearch}
             >
-              features
+              {dataset.varLabel.plural}
             </Button>
           ) : (
-            'features'
+            dataset.varLabel.plural
           )}{' '}
           to display their expression across groups, then choose a{' '}
           {showCategoriesBtn ? (

--- a/src/lib/components/dotplot/Dotplot.jsx
+++ b/src/lib/components/dotplot/Dotplot.jsx
@@ -204,7 +204,7 @@ export function Dotplot({
           ) : (
             dataset.varLabel.plural
           )}{' '}
-          to display their expression across groups, then choose a{' '}
+          to display their {dataset.valueLabel} across groups, then choose a{' '}
           {showCategoriesBtn ? (
             <Button
               variant="link"

--- a/src/lib/components/dotplot/DotplotControls.jsx
+++ b/src/lib/components/dotplot/DotplotControls.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 
+import _ from 'lodash';
 import { Button, Form, InputGroup } from 'react-bootstrap';
 
+import { useDataset } from '../../context/DatasetContext';
 import {
   useSettings,
   useSettingsDispatch,
@@ -11,6 +13,7 @@ import { ColorscaleSelect, ScaleSelect } from '../controls/Controls';
 export function DotplotControls() {
   const settings = useSettings();
   const dispatch = useSettingsDispatch();
+  const dataset = useDataset();
   const [controls, setControls] = useState({
     expressionCutoff: settings.controls.expressionCutoff,
     colorAxis: {
@@ -105,7 +108,7 @@ export function DotplotControls() {
         </Form.Group>
         <ScaleSelect plot="dotplot" />
         <Form.Group className="mb-2">
-          <Form.Label>Expression Cutoff</Form.Label>
+          <Form.Label>{_.capitalize(dataset.valueLabel)} Cutoff</Form.Label>
           <InputGroup>
             <Form.Control
               size="sm"
@@ -134,7 +137,7 @@ export function DotplotControls() {
           <Form.Check
             type="switch"
             id="meanOnlyExpressed"
-            label="Average only above cutoff"
+            label={`Average only above ${dataset.valueLabel} cutoff`}
             checked={settings.controls.meanOnlyExpressed}
             onChange={() => {
               dispatch({

--- a/src/lib/components/heatmap/Heatmap.jsx
+++ b/src/lib/components/heatmap/Heatmap.jsx
@@ -155,10 +155,10 @@ export function Heatmap({
               className="border-0 p-0 align-baseline"
               onClick={setShowSearch}
             >
-              features
+              {dataset.varLabel.plural}
             </Button>
           ) : (
-            'features'
+            dataset.varLabel.plural
           )}{' '}
           to display their expression, then choose a{' '}
           {showCategoriesBtn ? (

--- a/src/lib/components/heatmap/Heatmap.jsx
+++ b/src/lib/components/heatmap/Heatmap.jsx
@@ -160,7 +160,7 @@ export function Heatmap({
           ) : (
             dataset.varLabel.plural
           )}{' '}
-          to display their expression, then choose a{' '}
+          to display their {dataset.valueLabel}, then choose a{' '}
           {showCategoriesBtn ? (
             <Button
               variant="link"

--- a/src/lib/components/icons/HeatmapIcon.jsx
+++ b/src/lib/components/icons/HeatmapIcon.jsx
@@ -4,8 +4,8 @@ export default function HeatmapIcon({
   gap = 1,
   ...props
 }) {
-  const rows = 6; // genes
-  const cols = 8; // cells
+  const rows = 6; // features
+  const cols = 8; // observations
 
   // Example expression pattern for visual clusters
   const expressionLevels = [

--- a/src/lib/components/matrixplot/Matrixplot.jsx
+++ b/src/lib/components/matrixplot/Matrixplot.jsx
@@ -162,10 +162,10 @@ export function Matrixplot({
               className="border-0 p-0 align-baseline"
               onClick={setShowSearch}
             >
-              features
+              {dataset.varLabel.plural}
             </Button>
           ) : (
-            'features'
+            dataset.varLabel.plural
           )}{' '}
           to display the matrix plot.
         </p>

--- a/src/lib/components/offcanvas/OffCanvas.jsx
+++ b/src/lib/components/offcanvas/OffCanvas.jsx
@@ -1,6 +1,7 @@
 import Offcanvas from 'react-bootstrap/Offcanvas';
 
 import { SELECTION_MODES } from '../../constants/constants';
+import { useDataset } from '../../context/DatasetContext';
 import { ObsExplorer } from '../../views/PerturbationMap/ObsExplorer';
 import { ObsColsList } from '../obs-list/ObsList';
 import { ObsmKeysList } from '../obsm-list/ObsmList';
@@ -38,10 +39,11 @@ export function OffcanvasVars({
   handleClose,
   mode = SELECTION_MODES.MULTIPLE,
 }) {
+  const dataset = useDataset();
   return (
     <Offcanvas show={show} onHide={handleClose} className="offcanvas-vars">
       <Offcanvas.Header closeButton>
-        <Offcanvas.Title>Features</Offcanvas.Title>
+        <Offcanvas.Title>Search for {dataset.varLabel.plural}</Offcanvas.Title>
       </Offcanvas.Header>
       <Offcanvas.Body>
         <div className="sidebar-features">
@@ -69,10 +71,11 @@ export function OffcanvasControls({ show, handleClose, Controls, ...props }) {
 }
 
 export function OffcanvasObsExplorer({ show, handleClose, ...props }) {
+  const dataset = useDataset();
   return (
     <Offcanvas show={show} onHide={handleClose}>
       <Offcanvas.Header closeButton>
-        <Offcanvas.Title>Gene Perturbations</Offcanvas.Title>
+        <Offcanvas.Title>Search for {dataset.varLabel.plural}</Offcanvas.Title>
       </Offcanvas.Header>
       <Offcanvas.Body className="p-1">
         <div className="sidebar-features">

--- a/src/lib/components/offcanvas/OffCanvas.jsx
+++ b/src/lib/components/offcanvas/OffCanvas.jsx
@@ -75,7 +75,7 @@ export function OffcanvasObsExplorer({ show, handleClose, ...props }) {
   return (
     <Offcanvas show={show} onHide={handleClose}>
       <Offcanvas.Header closeButton>
-        <Offcanvas.Title>Search for {dataset.varLabel.plural}</Offcanvas.Title>
+        <Offcanvas.Title>Search for {dataset.obsLabel.plural}</Offcanvas.Title>
       </Offcanvas.Header>
       <Offcanvas.Body className="p-1">
         <div className="sidebar-features">

--- a/src/lib/components/plot/PlotTypeSelector.jsx
+++ b/src/lib/components/plot/PlotTypeSelector.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { PLOT_TYPES } from '../../constants/constants';
+import { useDataset } from '../../context/DatasetContext';
 import { StyledTooltip } from '../../utils/StyledTooltip';
 import DotPlotIcon from '../icons/DotPlotIcon';
 import HeatmapIcon from '../icons/HeatmapIcon';
@@ -13,36 +14,41 @@ const plotTypes = [
     type: PLOT_TYPES.SCATTERPLOT,
     icon: ScatterplotIcon,
     name: 'Scatterplot',
-    description: 'Displays cells in 2D based on dimensionality reduction.',
+    description: ({ obsLabel }) =>
+      `Displays ${obsLabel.plural} in 2D based on dimensionality reduction.`,
   },
   {
     type: PLOT_TYPES.MATRIXPLOT,
     icon: MatrixPlotIcon,
     name: 'Matrix Plot',
-    description: 'Shows expression values of genes across categories.',
+    description: ({ varLabel, valueLabel }) =>
+      `Shows ${valueLabel.singular} values of ${varLabel.plural} across categories.`,
   },
   {
     type: PLOT_TYPES.DOTPLOT,
     icon: DotPlotIcon,
     name: 'Dot Plot',
-    description: 'Shows proportion and expression of genes across groups.',
+    description: ({ varLabel, valueLabel }) =>
+      `Shows proportion and ${valueLabel.singular} of ${varLabel.plural} across groups.`,
   },
   {
     type: PLOT_TYPES.HEATMAP,
     icon: HeatmapIcon,
     name: 'Heatmap',
-    description:
-      'Visualises gene expression or feature activity as a colour-coded matrix.',
+    description: ({ varLabel, valueLabel }) =>
+      `Visualises ${valueLabel.singular} of ${varLabel.plural} as a colour-coded matrix.`,
   },
   {
     type: PLOT_TYPES.VIOLINPLOT,
     icon: ViolinPlotIcon,
     name: 'Violin Plot',
-    description: 'Displays distribution of gene expression across categories.',
+    description: ({ varLabel, valueLabel }) =>
+      `Displays distribution of ${valueLabel.singular} across ${varLabel.plural}.`,
   },
 ];
 
 export function PlotTypeSelector({ currentType, onChange }) {
+  const { obsLabel, varLabel, valueLabel } = useDataset();
   const [hoveredMap, setHoveredMap] = useState({});
 
   const handleMouseEnter = (type) =>
@@ -65,7 +71,7 @@ export function PlotTypeSelector({ currentType, onChange }) {
               <>
                 <strong>{name}</strong>
                 <br />
-                {description}
+                {description({ obsLabel, varLabel, valueLabel })}
               </>
             }
             placement="bottom"

--- a/src/lib/components/plot/PlotTypeSelector.jsx
+++ b/src/lib/components/plot/PlotTypeSelector.jsx
@@ -42,8 +42,8 @@ const plotTypes = [
     type: PLOT_TYPES.VIOLINPLOT,
     icon: ViolinPlotIcon,
     name: 'Violin Plot',
-    description: ({ varLabel, valueLabel }) =>
-      `Displays distribution of ${valueLabel} across ${varLabel.plural}.`,
+    description: ({ obsLabel, valueLabel }) =>
+      `Displays distribution of ${valueLabel} across ${obsLabel.plural}.`,
   },
 ];
 

--- a/src/lib/components/plot/PlotTypeSelector.jsx
+++ b/src/lib/components/plot/PlotTypeSelector.jsx
@@ -22,28 +22,28 @@ const plotTypes = [
     icon: MatrixPlotIcon,
     name: 'Matrix Plot',
     description: ({ varLabel, valueLabel }) =>
-      `Shows ${valueLabel.singular} values of ${varLabel.plural} across categories.`,
+      `Shows ${valueLabel} values of ${varLabel.plural} across categories.`,
   },
   {
     type: PLOT_TYPES.DOTPLOT,
     icon: DotPlotIcon,
     name: 'Dot Plot',
     description: ({ varLabel, valueLabel }) =>
-      `Shows proportion and ${valueLabel.singular} of ${varLabel.plural} across groups.`,
+      `Shows proportion and ${valueLabel} of ${varLabel.plural} across groups.`,
   },
   {
     type: PLOT_TYPES.HEATMAP,
     icon: HeatmapIcon,
     name: 'Heatmap',
     description: ({ varLabel, valueLabel }) =>
-      `Visualises ${valueLabel.singular} of ${varLabel.plural} as a colour-coded matrix.`,
+      `Visualises ${valueLabel} of ${varLabel.plural} as a colour-coded matrix.`,
   },
   {
     type: PLOT_TYPES.VIOLINPLOT,
     icon: ViolinPlotIcon,
     name: 'Violin Plot',
     description: ({ varLabel, valueLabel }) =>
-      `Displays distribution of ${valueLabel.singular} across ${varLabel.plural}.`,
+      `Displays distribution of ${valueLabel} across ${varLabel.plural}.`,
   },
 ];
 

--- a/src/lib/components/pseudospatial/Pseudospatial.jsx
+++ b/src/lib/components/pseudospatial/Pseudospatial.jsx
@@ -113,7 +113,7 @@ export function Pseudospatial({
   plotType,
   setPlotType,
 }) {
-  const { imageUrl } = useDataset();
+  const { imageUrl, valueLabel } = useDataset();
   const settings = useSettings();
   const dispatch = useSettingsDispatch();
   const [data, setData] = useState([]);
@@ -327,7 +327,7 @@ export function Pseudospatial({
               max={layout?.coloraxis?.cmax}
               addText={
                 plotType === PLOT_TYPES.GENE
-                  ? ' - Mean expression'
+                  ? ` - Mean ${valueLabel}`
                   : plotType === PLOT_TYPES.CATEGORICAL
                     ? ' - %'
                     : plotType === PLOT_TYPES.CONTINUOUS

--- a/src/lib/components/scatterplot/Scatterplot.jsx
+++ b/src/lib/components/scatterplot/Scatterplot.jsx
@@ -70,6 +70,7 @@ export function Scatterplot({
   setShowSearch,
   setPlotType,
   isFullscreen = false,
+  isSearchObs,
 }) {
   const { useUnsColors } = useDataset();
   const settings = useSettings();
@@ -639,6 +640,7 @@ export function Scatterplot({
             setShowCategories={setShowCategories}
             setShowSearch={setShowSearch}
             isFullscreen={isFullscreen}
+            isSearchObs={isSearchObs}
           />
         )}
         <div className="cherita-spatial-footer">

--- a/src/lib/components/scatterplot/SpatialControls.jsx
+++ b/src/lib/components/scatterplot/SpatialControls.jsx
@@ -28,6 +28,7 @@ import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Dropdown from 'react-bootstrap/Dropdown';
 
 import { ScatterplotControls } from './ScatterplotControls';
+import { useDataset } from '../../context/DatasetContext';
 import {
   useSettings,
   useSettingsDispatch,
@@ -48,6 +49,7 @@ export function SpatialControls({
   setShowSearch,
   isFullscreen,
 }) {
+  const dataset = useDataset();
   const settings = useSettings();
   const dispatch = useSettingsDispatch();
   const [showControls, setShowControls] = useState(false);
@@ -133,7 +135,7 @@ export function SpatialControls({
           {showCategoriesBtn && (
             <OverlayTrigger
               placement="right"
-              overlay={<Tooltip id="tooltip-obs">Browse categories</Tooltip>}
+              overlay={<Tooltip id="tooltip-obs">Explore categories</Tooltip>}
             >
               <Button
                 size={isCompact && 'sm'}
@@ -146,7 +148,11 @@ export function SpatialControls({
           {showSearchBtn && (
             <OverlayTrigger
               placement="right"
-              overlay={<Tooltip id="tooltip-vars">Search features</Tooltip>}
+              overlay={
+                <Tooltip id="tooltip-vars">
+                  Search {dataset.varLabel.plural}
+                </Tooltip>
+              }
             >
               <Button
                 size={isCompact && 'sm'}

--- a/src/lib/components/scatterplot/SpatialControls.jsx
+++ b/src/lib/components/scatterplot/SpatialControls.jsx
@@ -48,6 +48,7 @@ export function SpatialControls({
   setShowCategories,
   setShowSearch,
   isFullscreen,
+  isSearchObs = false,
 }) {
   const dataset = useDataset();
   const settings = useSettings();
@@ -150,7 +151,10 @@ export function SpatialControls({
               placement="right"
               overlay={
                 <Tooltip id="tooltip-vars">
-                  Search {dataset.varLabel.plural}
+                  Search{' '}
+                  {isSearchObs
+                    ? dataset.obsLabel.plural
+                    : dataset.varLabel.plural}
                 </Tooltip>
               }
             >

--- a/src/lib/components/scatterplot/Toolbox.jsx
+++ b/src/lib/components/scatterplot/Toolbox.jsx
@@ -1,9 +1,11 @@
 import { Button, ButtonGroup, OverlayTrigger, Tooltip } from 'react-bootstrap';
 
+import { useDataset } from '../../context/DatasetContext';
 import { formatNumerical } from '../../utils/string';
 import { ObsmKeysList } from '../obsm-list/ObsmList';
 
 export function Toolbox({ mode, obsLength, slicedLength, setHasObsm }) {
+  const { obsLabel } = useDataset();
   return (
     <div className="cherita-toolbox">
       <ButtonGroup>
@@ -17,7 +19,7 @@ export function Toolbox({ mode, obsLength, slicedLength, setHasObsm }) {
               overlay={
                 <Tooltip id="tooltip-dropped-mode">
                   You have selected {formatNumerical(slicedLength)} out of{' '}
-                  {formatNumerical(obsLength)} cells
+                  {formatNumerical(obsLength)} {obsLabel.plural}
                 </Tooltip>
               }
             >
@@ -28,7 +30,7 @@ export function Toolbox({ mode, obsLength, slicedLength, setHasObsm }) {
                 aria-disabled="true"
               >
                 {formatNumerical(slicedLength)} of {formatNumerical(obsLength)}{' '}
-                cells
+                {obsLabel.plural}
               </Button>
             </OverlayTrigger>
           ) : (
@@ -36,7 +38,7 @@ export function Toolbox({ mode, obsLength, slicedLength, setHasObsm }) {
               placement="top"
               overlay={
                 <Tooltip id="tooltip-dropped-mode">
-                  You are viewing {formatNumerical(obsLength)} cells
+                  You are viewing {formatNumerical(obsLength)} {obsLabel.plural}
                 </Tooltip>
               }
             >
@@ -46,7 +48,7 @@ export function Toolbox({ mode, obsLength, slicedLength, setHasObsm }) {
                 style={{ cursor: 'default' }}
                 aria-disabled="true"
               >
-                {formatNumerical(obsLength)} cells
+                {formatNumerical(obsLength)} {obsLabel.plural}
               </Button>
             </OverlayTrigger>
           ))}

--- a/src/lib/components/search-bar/SearchBar.jsx
+++ b/src/lib/components/search-bar/SearchBar.jsx
@@ -17,6 +17,7 @@ import {
   VarSearchResults,
 } from './SearchResults';
 import { COLOR_ENCODINGS } from '../../constants/constants';
+import { useDataset } from '../../context/DatasetContext';
 
 const select = (dispatch, item) => {
   dispatch({
@@ -86,6 +87,7 @@ export function SearchModal({
   const [varResultsLength, setVarResultsLength] = useState(null);
   const [diseaseResultsLength, setDiseaseResultsLength] = useState(null);
   const [obsResultsLength, setObsResultsLength] = useState(null);
+  const dataset = useDataset();
 
   return (
     <Modal show={show} onHide={handleClose} size="xl" fullscreen="xl-down">
@@ -143,7 +145,7 @@ export function SearchModal({
                       {searchVar && (
                         <Nav.Item>
                           <Nav.Link eventKey={FEATURE_TYPE.VAR}>
-                            Genes{' '}
+                            {_.capitalize(dataset.varLabel.plural)}{' '}
                             {!!varResultsLength && `(${varResultsLength})`}
                           </Nav.Link>
                         </Nav.Item>
@@ -160,7 +162,9 @@ export function SearchModal({
                       {searchObs && (
                         <Nav.Item>
                           <Nav.Link eventKey={FEATURE_TYPE.OBS}>
-                            Genes{' '}
+                            {_.capitalize(
+                              dataset.obsSearchCol || 'observations',
+                            )}{' '}
                             {!!obsResultsLength && `(${obsResultsLength})`}
                           </Nav.Link>
                         </Nav.Item>
@@ -253,9 +257,11 @@ export function SearchBar({
   searchObs = false,
 }) {
   const [text, setText] = useState('');
+  const dataset = useDataset();
   const displayText = [
-    ...(searchVar ? ['features'] : []),
+    ...(searchVar ? [dataset.varLabel.plural] : []),
     ...(searchDiseases ? ['diseases'] : []),
+    ...(searchObs ? [dataset.obsSearchCol?.trim() || 'observations'] : []),
   ].join(' and ');
 
   const [showModal, setShowModal] = useState(false);

--- a/src/lib/components/search-bar/SearchBar.jsx
+++ b/src/lib/components/search-bar/SearchBar.jsx
@@ -163,7 +163,7 @@ export function SearchModal({
                         <Nav.Item>
                           <Nav.Link eventKey={FEATURE_TYPE.OBS}>
                             {_.capitalize(
-                              dataset.obsSearchCol || 'observations',
+                              dataset.obsSearchCol?.trim() || 'observations',
                             )}{' '}
                             {!!obsResultsLength && `(${obsResultsLength})`}
                           </Nav.Link>

--- a/src/lib/components/search-bar/SearchBar.jsx
+++ b/src/lib/components/search-bar/SearchBar.jsx
@@ -162,9 +162,7 @@ export function SearchModal({
                       {searchObs && (
                         <Nav.Item>
                           <Nav.Link eventKey={FEATURE_TYPE.OBS}>
-                            {_.capitalize(
-                              dataset.obsSearchCol?.trim() || 'observations',
-                            )}{' '}
+                            {_.capitalize(dataset.obsLabel.plural)}{' '}
                             {!!obsResultsLength && `(${obsResultsLength})`}
                           </Nav.Link>
                         </Nav.Item>
@@ -261,7 +259,7 @@ export function SearchBar({
   const displayText = [
     ...(searchVar ? [dataset.varLabel.plural] : []),
     ...(searchDiseases ? ['diseases'] : []),
-    ...(searchObs ? [dataset.obsSearchCol?.trim() || 'observations'] : []),
+    ...(searchObs ? [dataset.obsLabel.plural] : []),
   ].join(' and ');
 
   const [showModal, setShowModal] = useState(false);

--- a/src/lib/components/search-bar/SearchInfo.jsx
+++ b/src/lib/components/search-bar/SearchInfo.jsx
@@ -204,7 +204,7 @@ export function DiseaseInfo({ disease, handleSelect, addVarSet }) {
   return (
     <div>
       <h5>{disease.disease_name}</h5>
-      <h6>Implicated genes</h6>
+      <h6>Implicated {dataset.varLabel.plural}</h6>
       {isPending ? (
         <p>Loading...</p>
       ) : (

--- a/src/lib/components/search-bar/SearchResults.jsx
+++ b/src/lib/components/search-bar/SearchResults.jsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import _ from 'lodash';
 import { Button, ListGroup } from 'react-bootstrap';
 
+import { useDataset } from '../../context/DatasetContext';
 import { useSettingsDispatch } from '../../context/SettingsContext';
 import {
   useDiseaseSearch,
@@ -100,11 +101,12 @@ function SearchResultsBase({
 }
 
 export function VarSearchResults(props) {
+  const dataset = useDataset();
   return (
     <SearchResultsBase
       {...props}
       searchHook={useVarSearch}
-      emptyLabel="Search features"
+      emptyLabel={`Search for ${dataset.varLabel.plural}`}
       itemRenderer={({
         item,
         dispatch,
@@ -140,11 +142,12 @@ export function VarSearchResults(props) {
 }
 
 export function ObsSearchResults(props) {
+  const dataset = useDataset();
   return (
     <SearchResultsBase
       {...props}
       searchHook={useObsSearch}
-      emptyLabel="Search observations"
+      emptyLabel={`Search for ${dataset.obsSearchCol || 'observations'}`}
       itemRenderer={({
         item,
         dispatch,
@@ -191,7 +194,7 @@ export function DiseasesSearchResults(props) {
     <SearchResultsBase
       {...props}
       searchHook={useDiseaseSearch}
-      emptyLabel="Search diseases"
+      emptyLabel="Search for diseases"
       overscan={250}
       estimateSize={() => 32}
       itemRenderer={({ item, setSelectedResult, selectedResult }) => (

--- a/src/lib/components/search-bar/SearchResults.jsx
+++ b/src/lib/components/search-bar/SearchResults.jsx
@@ -147,7 +147,7 @@ export function ObsSearchResults(props) {
     <SearchResultsBase
       {...props}
       searchHook={useObsSearch}
-      emptyLabel={`Search for ${dataset.obsSearchCol?.trim() || 'observations'}`}
+      emptyLabel={`Search for ${dataset.obsLabel.plural}`}
       itemRenderer={({
         item,
         dispatch,

--- a/src/lib/components/search-bar/SearchResults.jsx
+++ b/src/lib/components/search-bar/SearchResults.jsx
@@ -147,7 +147,7 @@ export function ObsSearchResults(props) {
     <SearchResultsBase
       {...props}
       searchHook={useObsSearch}
-      emptyLabel={`Search for ${dataset.obsSearchCol || 'observations'}`}
+      emptyLabel={`Search for ${dataset.obsSearchCol?.trim() || 'observations'}`}
       itemRenderer={({
         item,
         dispatch,

--- a/src/lib/components/toolbar/Toolbar.jsx
+++ b/src/lib/components/toolbar/Toolbar.jsx
@@ -8,7 +8,7 @@ export const Toolbar = ({
   setShowCategories,
   setShowSearch,
   setShowControls,
-  Fullscreen,
+  isFullscreen,
 }) => {
   const { showCategoriesBtn, showSearchBtn } = usePlotVisibility(isFullscreen);
   return (

--- a/src/lib/components/toolbar/Toolbar.jsx
+++ b/src/lib/components/toolbar/Toolbar.jsx
@@ -1,50 +1,10 @@
 import { faList, faSearch, faSliders } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import _ from 'lodash';
 import { Container, Nav, Navbar, Button, ButtonGroup } from 'react-bootstrap';
 
+import { useDataset } from '../../context/DatasetContext';
 import usePlotVisibility from '../../utils/usePlotVisibility';
-
-export const Toolbar = ({
-  setShowCategories,
-  setShowSearch,
-  setShowControls,
-  isFullscreen,
-}) => {
-  const { showCategoriesBtn, showSearchBtn } = usePlotVisibility(isFullscreen);
-  return (
-    <Navbar expand="md" bg="primary" variant="dark" className="cherita-navbar">
-      <Container fluid>
-        <Navbar.Toggle aria-controls="navbarScroll" />
-        <Navbar.Collapse id="navbarScroll">
-          <Nav navbarScroll>
-            {showCategoriesBtn && (
-              <Nav.Item className="me-2">
-                <Nav.Link onClick={() => setShowCategories(true)}>
-                  <FontAwesomeIcon icon={faList} className="me-2" />
-                  Explore Categories
-                </Nav.Link>
-              </Nav.Item>
-            )}
-            {showSearchBtn && (
-              <Nav.Item className="me-2">
-                <Nav.Link onClick={() => setShowSearch(true)}>
-                  <FontAwesomeIcon icon={faSearch} className="me-2" />
-                  Search Genes
-                </Nav.Link>
-              </Nav.Item>
-            )}
-            <Nav.Item className="me-2">
-              <Nav.Link onClick={() => setShowControls(true)}>
-                <FontAwesomeIcon icon={faSliders} className="me-2" />
-                Controls
-              </Nav.Link>
-            </Nav.Item>{' '}
-          </Nav>
-        </Navbar.Collapse>
-      </Container>
-    </Navbar>
-  );
-};
 
 export const PlotlyToolbar = ({
   setShowCategories,
@@ -52,6 +12,7 @@ export const PlotlyToolbar = ({
   isFullscreen,
 }) => {
   const { showCategoriesBtn, showSearchBtn } = usePlotVisibility(isFullscreen);
+  const dataset = useDataset();
   return (
     <ButtonGroup>
       {showCategoriesBtn && (
@@ -68,10 +29,10 @@ export const PlotlyToolbar = ({
         <Button
           variant="primary"
           onClick={() => setShowSearch(true)}
-          title="Search Genes"
+          title={`Search ${dataset.varLabel.plural}`}
         >
           <FontAwesomeIcon icon={faSearch} className="me-1" />
-          Genes
+          {_.capitalize(dataset.varLabel.plural)}
         </Button>
       )}
     </ButtonGroup>

--- a/src/lib/components/var-list/VarList.jsx
+++ b/src/lib/components/var-list/VarList.jsx
@@ -64,12 +64,10 @@ export const sortMeans = (i, means) => {
   return means[i.name] || _.min(_.values(means)) - 1;
 };
 
-export function VarNamesList({
-  mode = SELECTION_MODES.SINGLE,
-  displayName = 'genes',
-}) {
+export function VarNamesList({ mode = SELECTION_MODES.SINGLE }) {
   const settings = useSettings();
   const dispatch = useSettingsDispatch();
+  const dataset = useDataset();
 
   const selectedVar = useSelectedVar();
   const selectedMultiVar = useSelectedMultiVar();
@@ -180,8 +178,8 @@ export function VarNamesList({
   return (
     <div className="mt-3 d-flex flex-column h-100">
       <div className="d-flex justify-content-between mb-2">
-        <h5>{_.capitalize(displayName)}</h5>
-        <ButtonGroup aria-label="Feature options" size="sm">
+        <h5>{_.capitalize(dataset.varLabel.plural)}</h5>
+        <ButtonGroup aria-label="Options" size="sm">
           <Button
             variant="info"
             onClick={() => {
@@ -212,7 +210,9 @@ export function VarNamesList({
       </div>
       <>
         {!varList.length ? (
-          <Alert variant="light">Search for a feature.</Alert>
+          <Alert variant="light">
+            Search for a {dataset.varLabel.singular}
+          </Alert>
         ) : (
           <>
             <VarListToolbar />

--- a/src/lib/components/var-list/VarList.jsx
+++ b/src/lib/components/var-list/VarList.jsx
@@ -210,9 +210,7 @@ export function VarNamesList({ mode = SELECTION_MODES.SINGLE }) {
       </div>
       <>
         {!varList.length ? (
-          <Alert variant="light">
-            Search for a {dataset.varLabel.singular}
-          </Alert>
+          <Alert variant="light">Search for {dataset.varLabel.plural}</Alert>
         ) : (
           <>
             <VarListToolbar />

--- a/src/lib/components/var-list/VarListToolbar.jsx
+++ b/src/lib/components/var-list/VarListToolbar.jsx
@@ -56,7 +56,7 @@ export function VarListToolbar({ varType = 'var' }) {
     <div className="d-flex justify-content-end align-items-center mb-2">
       <ToggleButtonGroup
         name="sortfeatures"
-        aria-label="Sort features by"
+        aria-label="Sort by"
         size="sm"
         type="radio"
       >

--- a/src/lib/components/var-list/VarSet.jsx
+++ b/src/lib/components/var-list/VarSet.jsx
@@ -21,6 +21,7 @@ import {
 
 import { SelectionItem } from './VarItem';
 import { COLOR_ENCODINGS, SELECTION_MODES } from '../../constants/constants';
+import { useDataset } from '../../context/DatasetContext';
 import {
   useSettings,
   useSettingsDispatch,
@@ -45,6 +46,7 @@ function SelectionSet({
   removeSetVar,
   isMultiple = false,
 }) {
+  const dataset = useDataset();
   const [openSet, setOpenSet] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [searchText, setSearchText] = useState('');
@@ -63,7 +65,7 @@ function SelectionSet({
     })
   ) : (
     <ListGroup.Item>
-      <div className="text-muted">No features in this set</div>
+      <div className="text-muted">No {dataset.varLabel.plural} in this set</div>
     </ListGroup.Item>
   );
 
@@ -85,7 +87,8 @@ function SelectionSet({
               placement="top"
               overlay={
                 <Tooltip>
-                  This set represents the mean value of its features
+                  This set represents the mean value of its{' '}
+                  {dataset.varLabel.plural}
                 </Tooltip>
               }
             >
@@ -162,7 +165,7 @@ function SelectionSet({
         handleClose={() => setShowModal(false)}
         text={searchText}
         setText={setSearchText}
-        displayText={'features'}
+        displayText={dataset.varLabel.plural}
         handleSelect={(d, i) => {
           addVarToSet(d, set, i);
         }}

--- a/src/lib/components/violin/Violin.jsx
+++ b/src/lib/components/violin/Violin.jsx
@@ -223,10 +223,10 @@ export function Violin({
                 className="border-0 p-0 align-baseline"
                 onClick={setShowSearch}
               >
-                features
+                {dataset.varLabel.plural}
               </Button>
             ) : (
-              'features'
+              dataset.varLabel.plural
             )}{' '}
             to display their expression distributions across all observations.
           </p>
@@ -252,10 +252,10 @@ export function Violin({
                 className="border-0 p-0 align-baseline"
                 onClick={setShowSearch}
               >
-                feature
+                {dataset.varLabel.singular}
               </Button>
             ) : (
-              'feature'
+              dataset.varLabel.singular
             )}{' '}
             to view its distribution within each group.
           </p>

--- a/src/lib/components/violin/Violin.jsx
+++ b/src/lib/components/violin/Violin.jsx
@@ -228,8 +228,8 @@ export function Violin({
             ) : (
               dataset.varLabel.plural
             )}{' '}
-            to display their {dataset.valueLabel} distributions across all
-            observations.
+            to display their {dataset.valueLabel} distributions across all{' '}
+            {dataset.obsLabel.plural}.
           </p>
         )}
         {mode === VIOLIN_MODES.GROUPBY && (

--- a/src/lib/components/violin/Violin.jsx
+++ b/src/lib/components/violin/Violin.jsx
@@ -228,7 +228,8 @@ export function Violin({
             ) : (
               dataset.varLabel.plural
             )}{' '}
-            to display their expression distributions across all observations.
+            to display their {dataset.valueLabel} distributions across all
+            observations.
           </p>
         )}
         {mode === VIOLIN_MODES.GROUPBY && (

--- a/src/lib/context/DatasetContext.jsx
+++ b/src/lib/context/DatasetContext.jsx
@@ -66,6 +66,18 @@ const initialDataset = {
     dataUrl: null, // for additional data in a remote .parquet file
     dataFilterCols: null, // map of obs cols to filter data in .parquet file
   },
+  obsLabel: {
+    singular: 'cell',
+    plural: 'cells',
+  },
+  varLabel: {
+    singular: 'gene',
+    plural: 'genes',
+  },
+  valueLabel: {
+    singular: 'expression',
+    plural: 'expression',
+  },
 };
 
 export function DatasetProvider({ dataset_url, children, ...dataset_params }) {

--- a/src/lib/context/DatasetContext.jsx
+++ b/src/lib/context/DatasetContext.jsx
@@ -74,10 +74,7 @@ const initialDataset = {
     singular: 'gene',
     plural: 'genes',
   },
-  valueLabel: {
-    singular: 'expression',
-    plural: 'expression',
-  },
+  valueLabel: 'expression',
 };
 
 export function DatasetProvider({ dataset_url, children, ...dataset_params }) {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -18,7 +18,6 @@ export { Pseudospatial } from './components/pseudospatial/Pseudospatial';
 export { Scatterplot } from './components/scatterplot/Scatterplot';
 export { ScatterplotControls } from './components/scatterplot/ScatterplotControls';
 export { SearchBar } from './components/search-bar/SearchBar';
-export { Toolbar } from './components/toolbar/Toolbar';
 export { VarNamesList } from './components/var-list/VarList';
 export { Violin } from './components/violin/Violin';
 export { ViolinControls } from './components/violin/ViolinControls';

--- a/src/lib/views/PerturbationMap/ObsExplorer.jsx
+++ b/src/lib/views/PerturbationMap/ObsExplorer.jsx
@@ -149,8 +149,8 @@ export function ObsExplorer() {
   if (selectedObsIndex == null) {
     return (
       <div className="my-4 text-muted">
-        Select a point in the scatterplot to view details about the gene
-        perturbation.
+        Select a point in the scatterplot or search for genes to view details
+        about the gene perturbation.
       </div>
     );
   }

--- a/src/lib/views/PerturbationMap/ObsExplorer.jsx
+++ b/src/lib/views/PerturbationMap/ObsExplorer.jsx
@@ -136,7 +136,7 @@ export function ObsExplorer() {
   const [showModal, setShowModal] = useState(false);
 
   const { selectedObsIndex } = useSettings();
-  const { obsExplorer = {} } = useDataset();
+  const { obsExplorer = {}, varLabel, valueLabel } = useDataset();
   useParquet(); // initialize duckdb instance
 
   const {
@@ -149,8 +149,8 @@ export function ObsExplorer() {
   if (selectedObsIndex == null) {
     return (
       <div className="my-4 text-muted">
-        Select a point in the scatterplot or search for genes to view details
-        about the gene perturbation.
+        Select a point in the scatterplot or search for {varLabel.plural} to view details
+        about the {varLabel.singular} perturbation.
       </div>
     );
   }
@@ -169,7 +169,7 @@ export function ObsExplorer() {
             title={
               <>
                 This panel shows metadata and predicted downstream effects for
-                the selected gene perturbation across the atlas.
+                the selected {varLabel.singular} perturbation across the atlas.
               </>
             }
             placement="right"
@@ -184,7 +184,7 @@ export function ObsExplorer() {
             <Tooltip
               title={
                 <>
-                  These values describe how the selected gene perturbation is
+                  These values describe how the selected {varLabel.singular} perturbation is
                   annotated in the atlas, including lineage, biological context,
                   and summary scores used in the perturbation landscape.
                 </>
@@ -242,7 +242,7 @@ export function ObsExplorer() {
               <Tooltip
                 title={
                   <>
-                    This table shows genes predicted to change expression in
+                    This table shows {varLabel.plural} predicted to change {valueLabel} in
                     response to the selected perturbation. Results can be sorted
                     and explored to identify affected pathways and regulatory
                     programs.

--- a/src/lib/views/PerturbationMap/ObsExplorer.jsx
+++ b/src/lib/views/PerturbationMap/ObsExplorer.jsx
@@ -136,7 +136,7 @@ export function ObsExplorer() {
   const [showModal, setShowModal] = useState(false);
 
   const { selectedObsIndex } = useSettings();
-  const { obsExplorer = {}, varLabel, valueLabel } = useDataset();
+  const { obsExplorer = {}, obsLabel, valueLabel } = useDataset();
   useParquet(); // initialize duckdb instance
 
   const {
@@ -149,8 +149,8 @@ export function ObsExplorer() {
   if (selectedObsIndex == null) {
     return (
       <div className="my-4 text-muted">
-        Select a point in the scatterplot or search for {varLabel.plural} to view details
-        about the {varLabel.singular} perturbation.
+        Select a point in the scatterplot or search for {obsLabel.plural} to
+        view details about the {obsLabel.singular} perturbation.
       </div>
     );
   }
@@ -169,7 +169,7 @@ export function ObsExplorer() {
             title={
               <>
                 This panel shows metadata and predicted downstream effects for
-                the selected {varLabel.singular} perturbation across the atlas.
+                the selected {obsLabel.singular} perturbation across the atlas.
               </>
             }
             placement="right"
@@ -184,9 +184,10 @@ export function ObsExplorer() {
             <Tooltip
               title={
                 <>
-                  These values describe how the selected {varLabel.singular} perturbation is
-                  annotated in the atlas, including lineage, biological context,
-                  and summary scores used in the perturbation landscape.
+                  These values describe how the selected {obsLabel.singular}{' '}
+                  perturbation is annotated in the atlas, including lineage,
+                  biological context, and summary scores used in the
+                  perturbation landscape.
                 </>
               }
               placement="right"
@@ -242,10 +243,10 @@ export function ObsExplorer() {
               <Tooltip
                 title={
                   <>
-                    This table shows {varLabel.plural} predicted to change {valueLabel} in
-                    response to the selected perturbation. Results can be sorted
-                    and explored to identify affected pathways and regulatory
-                    programs.
+                    This table shows {obsLabel.plural} predicted to change{' '}
+                    {valueLabel} in response to the selected perturbation.
+                    Results can be sorted and explored to identify affected
+                    pathways and regulatory programs.
                   </>
                 }
                 placement="right"

--- a/src/lib/views/PerturbationMap/StandardView.jsx
+++ b/src/lib/views/PerturbationMap/StandardView.jsx
@@ -45,6 +45,7 @@ export function StandardView({ ...props }) {
               setShowControls={setShowControls}
               isFullscreen={true}
               pointInteractionEnabled={true}
+              isSearchObs={true}
             />
           </div>
           <div className="cherita-app-sidebar p-3">

--- a/website/docs/config/settings.md
+++ b/website/docs/config/settings.md
@@ -23,7 +23,7 @@ Props passed to `DatasetProvider` define the values in `DatasetContext` and can 
 ### Usage
 
 ```jsx
-import { DatasetProvider, Scatterplot } from "@haniffalab/cherita-react";
+import { DatasetProvider, Scatterplot } from '@haniffalab/cherita-react';
 
 <DatasetProvider
   dataset_url="https://remote-anndata.zarr"
@@ -31,73 +31,100 @@ import { DatasetProvider, Scatterplot } from "@haniffalab/cherita-react";
   enableObsGroups={true}
 >
   <Scatterplot />
-</DatasetProvider>
+</DatasetProvider>;
 ```
 
 When using views, props should be provided to the view component which are then passed to the `DatasetProvider`
 
 ```jsx
-import { ObservationFeature } from "@haniffalab/cherita-react";
+import { ObservationFeature } from '@haniffalab/cherita-react';
 
 <ObservationFeature.StandardView
   dataset_url="https://remote-anndata.zarr"
   enableObsGroups={false}
-/>
+/>;
+```
+
+To customise the terminology used in the UI for your data modality, pass `obsLabel`, `varLabel` and `valueLabel` props:
+
+```jsx
+// Visium spatial transcriptomics (spots + genes + expression)
+<DatasetProvider
+  dataset_url="https://remote-anndata.zarr"
+  obsLabel={{ singular: "spot", plural: "spots" }}
+  varLabel={{ singular: "gene", plural: "genes" }}
+  valueLabel="expression"
+>
+  <Scatterplot />
+</DatasetProvider>
+
+// ATAC-seq (cells + peaks + accessibility)
+<DatasetProvider
+  dataset_url="https://remote-anndata.zarr"
+  obsLabel={{ singular: "cell", plural: "cells" }}
+  varLabel={{ singular: "peak", plural: "peaks" }}
+  valueLabel="accessibility"
+>
+  <Scatterplot />
+</DatasetProvider>
 ```
 
 ### Props
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `dataset_url` | `string` | required | URL to the AnnData-Zarr file |
-| `varNamesCol` | `string` | `null` | Column name for variable names to show in the [VarNamesCol](../components/metadata.md#varnameslist) and to use in the [SearchBar](../components/metadata.md#searchbar). For cases where the index of the `var` table holds id's or values not clear to the user |
-| `obsSearchCol` | `string` | `null` | Column for observation search. Used by [SearchBar](../components/metadata.md#searchbar) when it is set with `searchObs` as `true` |
-| `diseaseDatasets` | `array` | `[]` | Disease dataset configurations |
-| `obsGroups` | `object` | `null` | Custom observation groupings |
-| `imageUrl` | `string` | `null` | URL for spatial image |
-| `useUnsColors` | `boolean` | `false` | Use `uns` colors from AnnData |
-| `isPseudospatial` | `boolean` | `false` | Enable pseudospatial mode |
-| `obsExplorer` | `object` | `{ obsCols: [], dataUrl: null, dataFilterCols: null }` | Data to load in the [ObsExplorer](../components/metadata.md#obsexplorer) component. `obsCols` is a list of columns from the `obs` table in the dataset to be loaded and displayed in the component. If undefined or empty, all columns are displayed. `dataUrl` is the location of a remote Parquet file with additional data to load. `dataFilterCols` is a map between columns in the `obs` table of the dataset and columns in the Parquet file to filter the data to load from the Parquet file. e.g., `dataFilterCols: {obs_id: parquet_id}` will filter the Parquet data to only those rows where `parquet_id` matches the selected observation's `obs_id` value |
-| `canOverrideSettings` | `boolean` | `true` | Allow settings updated by user selections to be stored in the browser. When set to `false` only the `defaultSettings` will be considered on initial load of the dataset |
-| `defaultSettings` | `object` | `{}` | Default values for `SettingsContext`, useful to set pre-selected values when data loads |
+| Prop                  | Type      | Default                                                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --------------------- | --------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dataset_url`         | `string`  | required                                               | URL to the AnnData-Zarr file                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `varNamesCol`         | `string`  | `null`                                                 | Column name for variable names to show in the [VarNamesCol](../components/metadata.md#varnameslist) and to use in the [SearchBar](../components/metadata.md#searchbar). For cases where the index of the `var` table holds id's or values not clear to the user                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `obsSearchCol`        | `string`  | `null`                                                 | Column for observation search. Used by [SearchBar](../components/metadata.md#searchbar) when it is set with `searchObs` as `true`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `diseaseDatasets`     | `array`   | `[]`                                                   | Disease dataset configurations                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `obsGroups`           | `object`  | `null`                                                 | Custom observation groupings                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `imageUrl`            | `string`  | `null`                                                 | URL for spatial image                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `useUnsColors`        | `boolean` | `false`                                                | Use `uns` colors from AnnData                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `isPseudospatial`     | `boolean` | `false`                                                | Enable pseudospatial mode                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `obsExplorer`         | `object`  | `{ obsCols: [], dataUrl: null, dataFilterCols: null }` | Data to load in the [ObsExplorer](../components/metadata.md#obsexplorer) component. `obsCols` is a list of columns from the `obs` table in the dataset to be loaded and displayed in the component. If undefined or empty, all columns are displayed. `dataUrl` is the location of a remote Parquet file with additional data to load. `dataFilterCols` is a map between columns in the `obs` table of the dataset and columns in the Parquet file to filter the data to load from the Parquet file. e.g., `dataFilterCols: {obs_id: parquet_id}` will filter the Parquet data to only those rows where `parquet_id` matches the selected observation's `obs_id` value |
+| `obsLabel`            | `object`  | `{ singular: 'cell', plural: 'cells' }`                | Labels used in the UI to refer to observations (rows). Override this to match your data modality, e.g. `{ singular: 'spot', plural: 'spots' }` for spatial transcriptomics or `{ singular: 'nucleus', plural: 'nuclei' }` for single-nucleus data                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `varLabel`            | `object`  | `{ singular: 'gene', plural: 'genes' }`                | Labels used in the UI to refer to variables (columns). Override this to match your data modality, e.g. `{ singular: 'peak', plural: 'peaks' }` for ATAC-seq or `{ singular: 'protein', plural: 'proteins' }` for proteomics                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `valueLabel`          | `string`  | `'expression'`                                         | Label used in the UI to describe matrix values. Override this to match your data modality, e.g. `'accessibility'` for chromatin data or `'activity'` for transcription factor activity                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `canOverrideSettings` | `boolean` | `true`                                                 | Allow settings updated by user selections to be stored in the browser. When set to `false` only the `defaultSettings` will be considered on initial load of the dataset                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `defaultSettings`     | `object`  | `{}`                                                   | Default values for `SettingsContext`, useful to set pre-selected values when data loads                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 
 #### `defaultSettings`
 
 Initial settings values can be provided as an object so a dataset is loaded with customized pre-selected values. All values handled by `SettingsContext` (except for `data` which are values resolved when the dataset is loaded) can be set through `defaultSettings`, however it is most useful for selections like `selectedObs`, `selectedVar`, `selectedObsm`, `selectedMultiVar`, `colorEncoding`.
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `selectedObs` | `object` | `null` | Selected `obs` column like ` {name: "obs_name" }` |
-| `selectedVar` | `object` | `null` | Selected variable for visualization (can be single variable or variable set) |
-| `selectedObsm` | `object` | `null` | Selected observation matrix for dimensional reduction plots (e.g., "X_umap") |
-| `selectedMultiVar` | `array` | `[]` | Array of multiple selected variables for comparison |
-| `labelObs` | `array` | `[]` | Array of observation column names to display in the tooltips in the [Scatterplot](../components/plots.md#scatterplot) |
-| `vars` | `array` | `[]` | Array of variables available for selection |
-| `colorEncoding` | `COLOR_ENCODINGS` | `null` | Type of color encoding (variable-based or observation-based) |
-| `sliceBy` | `object` | `{ obs: false, polygons: false }` | Configuration for data slicing by observations or polygons |
-| `polygons` | `object` | `{}` | Polygon selection configurations for spatial plots |
-| `controls` | `object` | [See below](./settings.md#controls-default) | Plot controls |
-| `varSort` | `object` | `{}` | Variable sorting configuration |
-| `pseudospatial` | `object` | [See below](./settings.md#pseudospatial-default) | Pseudospatial plot controls |
-| `selectedObsIndex` | `int` | `null` | Index of currently selected observation |
+| Key                | Type              | Default                                          | Description                                                                                                           |
+| ------------------ | ----------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `selectedObs`      | `object`          | `null`                                           | Selected `obs` column like ` {name: "obs_name" }`                                                                     |
+| `selectedVar`      | `object`          | `null`                                           | Selected variable for visualization (can be single variable or variable set)                                          |
+| `selectedObsm`     | `object`          | `null`                                           | Selected observation matrix for dimensional reduction plots (e.g., "X_umap")                                          |
+| `selectedMultiVar` | `array`           | `[]`                                             | Array of multiple selected variables for comparison                                                                   |
+| `labelObs`         | `array`           | `[]`                                             | Array of observation column names to display in the tooltips in the [Scatterplot](../components/plots.md#scatterplot) |
+| `vars`             | `array`           | `[]`                                             | Array of variables available for selection                                                                            |
+| `colorEncoding`    | `COLOR_ENCODINGS` | `null`                                           | Type of color encoding (variable-based or observation-based)                                                          |
+| `sliceBy`          | `object`          | `{ obs: false, polygons: false }`                | Configuration for data slicing by observations or polygons                                                            |
+| `polygons`         | `object`          | `{}`                                             | Polygon selection configurations for spatial plots                                                                    |
+| `controls`         | `object`          | [See below](./settings.md#controls-default)      | Plot controls                                                                                                         |
+| `varSort`          | `object`          | `{}`                                             | Variable sorting configuration                                                                                        |
+| `pseudospatial`    | `object`          | [See below](./settings.md#pseudospatial-default) | Pseudospatial plot controls                                                                                           |
+| `selectedObsIndex` | `int`             | `null`                                           | Index of currently selected observation                                                                               |
 
 ##### `controls` {#controls-default}
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `colorScale` | `string` | `'Viridis'` | Default color scale for visualization |
-| `range` | `array` | `[0, 1]` | Normalized range for color mapping [min, max] |
-| `colorAxis` | `object` | `{ dmin: 0, dmax: 1, cmin: 0, cmax: 1}` | Color axis configuration with data and color limits |
-| `scale` | `object` | `{ dotplot: DOTPLOT_SCALES.NONE.value, matrixplot: MATRIXPLOT_SCALES.NONE.value, violinplot: VIOLINPLOT_SCALES.WIDTH.value}` | Scaling options for different plot types |
-| `meanOnlyExpressed` | `bool` | `false` | Whether to calculate mean only from expressed cells |
-| `expressionCutoff` | `float` | 0.0 | Minimum expression threshold for calculations |
-| `radiusScale` | `string` | `{}` | Scale configuration for radius-based visualizations |
+| Key                 | Type     | Default                                                                                                                      | Description                                         |
+| ------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `colorScale`        | `string` | `'Viridis'`                                                                                                                  | Default color scale for visualization               |
+| `range`             | `array`  | `[0, 1]`                                                                                                                     | Normalized range for color mapping [min, max]       |
+| `colorAxis`         | `object` | `{ dmin: 0, dmax: 1, cmin: 0, cmax: 1}`                                                                                      | Color axis configuration with data and color limits |
+| `scale`             | `object` | `{ dotplot: DOTPLOT_SCALES.NONE.value, matrixplot: MATRIXPLOT_SCALES.NONE.value, violinplot: VIOLINPLOT_SCALES.WIDTH.value}` | Scaling options for different plot types            |
+| `meanOnlyExpressed` | `bool`   | `false`                                                                                                                      | Whether to calculate mean only from expressed cells |
+| `expressionCutoff`  | `float`  | 0.0                                                                                                                          | Minimum expression threshold for calculations       |
+| `radiusScale`       | `string` | `{}`                                                                                                                         | Scale configuration for radius-based visualizations |
 
 ##### `pseudospatial` {#pseudospatial-default}
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `maskSet` | `string` | `null` | Selected mask set for pseudospatial visualization |
-| `maskValues` | `string` | `null` | Selected mask values within the chosen mask set |
-| `categoricalMode` | `PSEUDOSPATIAL_CATEGORICAL_MODES` | `PSEUDOSPATIAL_CATEGORICAL_MODES.ACROSS.value` | Mode for categorical pseudospatial visualization |
-| `refImg` | `object` | `{ visible: false, opacity: 1 }` | Reference image configuration for spatial context |
+| Key               | Type                              | Default                                        | Description                                       |
+| ----------------- | --------------------------------- | ---------------------------------------------- | ------------------------------------------------- |
+| `maskSet`         | `string`                          | `null`                                         | Selected mask set for pseudospatial visualization |
+| `maskValues`      | `string`                          | `null`                                         | Selected mask values within the chosen mask set   |
+| `categoricalMode` | `PSEUDOSPATIAL_CATEGORICAL_MODES` | `PSEUDOSPATIAL_CATEGORICAL_MODES.ACROSS.value` | Mode for categorical pseudospatial visualization  |
+| `refImg`          | `object`                          | `{ visible: false, opacity: 1 }`               | Reference image configuration for spatial context |


### PR DESCRIPTION
# Description

This PR enhances the UI to use dataset-driven labels instead of hard-coded terminology like “cells” and “genes”. This makes text flexible to different data modalities by using values from the dataset configuration (DatasetContext), including:

- obs axis (cells, spots, samples, nuclei, …)
- var axis (genes, peaks, proteins, features, …)
- value semantics (expression, accessibility, activity)

Changes include:

- Adding new values into the dataset configuration to store semantic values for "obs", "var" and matrix "values".  
- Replacing static strings in search modals, lists, and toolbars to use these dynamic terms `dataset.varLabel`, `dataset.obsLabel`, and `dataset.valueLabel`
- Updated static text used when searching "obs" (i.e. perturbgen), to use string value from `obsSearchCol`
- Cleaning up legacy hardcoded text and removing unnecessary props like `displayName`

Fixes #238 
Related to # (if applicable)

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that resolves an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [ ] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [ ] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
