### PR TITLE
fix: bump plotly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "ndarray-unpack": "^1.0.0",
         "nebula.gl": "^1.0.4",
         "numbro": "^2.5.0",
-        "plotly.js": "^2.23.2",
+        "plotly.js": "^3.4.0",
         "popper.js": "^1.16.1",
         "react-bootstrap": "^2.7.4",
         "react-plotly.js": "^2.6.0",
@@ -5160,6 +5160,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@plotly/regl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@plotly/regl/-/regl-2.1.2.tgz",
+      "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw==",
+      "license": "MIT"
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.17",
@@ -13089,53 +13095,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/css-loader": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.3.tgz",
-      "integrity": "sha512-frbERmjT0UC5lMheWpJmMilnt9GEhbZJN/heUb7/zaJYeIzj5St9HvDcfshzzOqbsS+rYpMk++2SD3vGETDSyA==",
-      "license": "MIT",
-      "dependencies": {
-        "icss-utils": "^5.1.0",
-        "postcss": "^8.4.40",
-        "postcss-modules-extract-imports": "^3.1.0",
-        "postcss-modules-local-by-default": "^4.0.5",
-        "postcss-modules-scope": "^3.2.0",
-        "postcss-modules-values": "^4.0.0",
-        "postcss-value-parser": "^4.2.0",
-        "semver": "^7.6.3"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "webpack": "^5.27.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/css-loader/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/css-minimizer-webpack-plugin": {
@@ -27312,15 +27271,16 @@
       }
     },
     "node_modules/plotly.js": {
-      "version": "2.35.3",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.35.3.tgz",
-      "integrity": "sha512-7RaC6FxmCUhpD6H4MpD+QLUu3hCn76I11rotRefrh3m1iDvWqGnVqVk9dSaKmRAhFD3vsNsYea0OxnR1rc2IzQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-3.4.0.tgz",
+      "integrity": "sha512-jdWfHLB8AxlGUmVhqJTGEKdwjCKGn9Yi8yg16067/JyqseuSado7F6IOM1XPZspdZyO/cf8IPuy7ROlVhqZZNw==",
       "license": "MIT",
       "dependencies": {
         "@plotly/d3": "3.8.2",
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",
         "@plotly/mapbox-gl": "1.13.4",
+        "@plotly/regl": "^2.1.2",
         "@turf/area": "^7.1.0",
         "@turf/bbox": "^7.1.0",
         "@turf/centroid": "^7.1.0",
@@ -27329,9 +27289,8 @@
         "color-alpha": "1.0.4",
         "color-normalize": "1.5.0",
         "color-parse": "2.0.0",
-        "color-rgba": "2.1.1",
+        "color-rgba": "3.0.0",
         "country-regex": "^1.1.0",
-        "css-loader": "^7.1.2",
         "d3-force": "^1.2.1",
         "d3-format": "^1.4.5",
         "d3-geo": "^1.12.1",
@@ -27346,7 +27305,7 @@
         "has-hover": "^1.0.1",
         "has-passive-events": "^1.0.0",
         "is-mobile": "^4.0.0",
-        "maplibre-gl": "^4.5.2",
+        "maplibre-gl": "^4.7.1",
         "mouse-change": "^1.4.0",
         "mouse-event-offset": "^3.0.2",
         "mouse-wheel": "^1.2.0",
@@ -27355,21 +27314,38 @@
         "point-in-polygon": "^1.1.0",
         "polybooljs": "^1.2.2",
         "probe-image-size": "^7.2.3",
-        "regl": "npm:@plotly/regl@^2.1.2",
         "regl-error2d": "^2.0.12",
         "regl-line2d": "^3.1.3",
         "regl-scatter2d": "^3.3.1",
         "regl-splom": "^1.0.14",
         "strongly-connected-components": "^1.0.1",
-        "style-loader": "^4.0.0",
         "superscript-text": "^1.0.0",
         "svg-path-sdf": "^1.1.3",
         "tinycolor2": "^1.4.2",
         "to-px": "1.0.1",
         "topojson-client": "^3.1.0",
         "webgl-context": "^2.2.0",
-        "world-calendars": "^1.0.3"
+        "world-calendars": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
+    },
+    "node_modules/plotly.js/node_modules/color-rgba": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
+      "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-parse": "^2.0.0",
+        "color-space": "^2.0.0"
+      }
+    },
+    "node_modules/plotly.js/node_modules/color-space": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.3.2.tgz",
+      "integrity": "sha512-BcKnbOEsOarCwyoLstcoEztwT0IJxqqQkNwDuA3a65sICvvHL2yoeV13psoDFh5IuiOMnIOKdQDwB4Mk3BypiA==",
+      "license": "Unlicense"
     },
     "node_modules/plotly.js/node_modules/d3-format": {
       "version": "1.4.5",
@@ -34375,22 +34351,6 @@
       "license": "ISC",
       "dependencies": {
         "xml-escape": "1.1.0"
-      }
-    },
-    "node_modules/style-loader": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
-      "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.27.0"
       }
     },
     "node_modules/styled-components": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ndarray-unpack": "^1.0.0",
     "nebula.gl": "^1.0.4",
     "numbro": "^2.5.0",
-    "plotly.js": "^2.23.2",
+    "plotly.js": "^3.4.0",
     "popper.js": "^1.16.1",
     "react-bootstrap": "^2.7.4",
     "react-plotly.js": "^2.6.0",

--- a/src/lib/constants/constants.js
+++ b/src/lib/constants/constants.js
@@ -96,7 +96,6 @@ export const PLOTLY_MODEBAR_BUTTONS = [
   'zoomIn2d',
   'zoomOut2d',
   'autoScale2d',
-  'resetScale2d',
 ];
 
 export const BREAKPOINTS = {


### PR DESCRIPTION
# Description

bump plotly to version 3.4.0
fix: remove resetscale button from plotly toolbar as confusing with autoscale

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [x] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [x] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
