### PR TITLE
fix: where var with matrix_index 0 not in active

### DIFF
--- a/src/lib/components/var-list/VarItem.jsx
+++ b/src/lib/components/var-list/VarItem.jsx
@@ -164,8 +164,7 @@ export function SelectionItem({
                       : 'Set as color encoding'
                 }
               >
-                {!isMultiple && <FontAwesomeIcon icon={faDroplet} />}
-                {isMultiple && <FontAwesomeIcon icon={faCheck} />}
+                <FontAwesomeIcon icon={isMultiple ? faCheck : faDroplet} />
               </Button>
             )}
             {showRemove && (

--- a/src/lib/components/var-list/VarList.jsx
+++ b/src/lib/components/var-list/VarList.jsx
@@ -77,20 +77,20 @@ export function VarNamesList({
 
   const [active, setActive] = useState(
     mode === SELECTION_MODES.SINGLE
-      ? selectedVar?.matrix_index || selectedVar?.name
-      : selectedMultiVar.map((i) => i.matrix_index || i.name),
+      ? (selectedVar?.matrix_index ?? selectedVar?.name)
+      : selectedMultiVar.map((i) => i.matrix_index ?? i.name),
   );
   const [sortedVars, setSortedVars] = useState([]);
 
   useEffect(() => {
     if (mode === SELECTION_MODES.SINGLE) {
-      setActive(selectedVar?.matrix_index || selectedVar?.name);
+      setActive(selectedVar?.matrix_index ?? selectedVar?.name);
     }
   }, [mode, selectedVar]);
 
   useEffect(() => {
     if (mode === SELECTION_MODES.MULTIPLE) {
-      setActive(selectedMultiVar.map((i) => i.matrix_index || i.name));
+      setActive(selectedMultiVar.map((i) => i.matrix_index ?? i.name));
     }
   }, [mode, selectedMultiVar]);
 


### PR DESCRIPTION
# Description

fix bug where vars with matrix_index 0 were not correctly added to `active` and so would appear as unselected in the varlist

## Type of change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [ ] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [x] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
